### PR TITLE
Fix settings page option selection

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -12,7 +12,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <link rel="apple-touch-icon" href="icons/icon-192x192.png">
   <link rel="stylesheet" href="css/main.css">
-  <link rel="stylesheet" href="css/themes/wood.css" id="theme-css">
+  <link rel="stylesheet" href="./assets/wood-dGYy0LCH.css" id="theme-css">
     <script>
         // Function to update theme
         function updateTheme() {
@@ -240,6 +240,24 @@
             .settings-content {
                 padding: 1.5rem;
             }
+        }
+        /* Ensure option selection is visibly reflected */
+        .theme-option.selected {
+            border-color: var(--primary-color);
+            background: var(--primary-color);
+            color: white;
+            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+        }
+        .difficulty-option.selected {
+            border-color: var(--primary-color);
+            background: var(--primary-color);
+            color: white !important;
+            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5) !important;
+        }
+        .difficulty-option.selected h4,
+        .difficulty-option.selected p {
+            color: white !important;
+            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7) !important;
         }
     </style>
   <script type="module" crossorigin src="./assets/settings-C_a3uKl2.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -11,6 +11,8 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <link rel="apple-touch-icon" href="icons/icon-192x192.png">
+  <link rel="stylesheet" href="css/main.css">
+  <link rel="stylesheet" href="css/themes/wood.css" id="theme-css">
     <script>
         // Function to update theme
         function updateTheme() {


### PR DESCRIPTION
Add missing CSS links and inline selected-state styles to `settings.html` to ensure option selections visibly update.

The settings page was not visually reflecting selected options (themes, difficulty) because the necessary CSS files (`main.css` and the correct theme CSS) were not linked, and the specific `.selected` styles were missing or not applied correctly. This PR directly addresses that by linking the styles and inlining the selected-state rules for immediate visual feedback.

---
<a href="https://cursor.com/background-agent?bcId=bc-a81bfbcb-1e6f-4f14-b569-e0ac946e9e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a81bfbcb-1e6f-4f14-b569-e0ac946e9e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

