### PR TITLE
Adjust game scoring and combo points

### DIFF
--- a/src/js/game/scoring.js
+++ b/src/js/game/scoring.js
@@ -154,8 +154,11 @@ export class ScoringSystem {
         scoreGained += clearedLines.columns.length * this.basePoints.line;
         scoreGained += clearedLines.squares.length * this.basePoints.square;
         
-        // Combo bonus: when 2+ different types clear simultaneously, add flat +25
-        if (this.combo >= 1) {
+        // Combo bonus: apply +25 when the CURRENT clear includes 2+ different types
+        const currentClearTypesCount = (clearedLines.rows.length > 0 ? 1 : 0)
+            + (clearedLines.columns.length > 0 ? 1 : 0)
+            + (clearedLines.squares.length > 0 ? 1 : 0);
+        if (currentClearTypesCount >= 2) {
             scoreGained += 25;
         }
         


### PR DESCRIPTION
Reduce 3x3 square clear points to 15 and simplify combo bonus to a flat +25 for simultaneous multi-type clears as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-86467e38-4369-4ca8-9ae6-8d94f066e71f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-86467e38-4369-4ca8-9ae6-8d94f066e71f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

