### PR TITLE
Adjust scoring for clears and combos

### DIFF
--- a/src/js/game/scoring.js
+++ b/src/js/game/scoring.js
@@ -24,8 +24,8 @@ export class ScoringSystem {
         // Scoring multipliers
         this.basePoints = {
             single: 1,
-            line: 10,
-            square: 15,
+            line: 15,
+            square: 20,
             combo: 5
         };
     }
@@ -173,13 +173,13 @@ export class ScoringSystem {
         this.pointsBreakdown.linePoints += linePointsAdded;
         this.pointsBreakdown.squarePoints += squarePointsAdded;
         
-        // Combo bonus: apply +25 when the CURRENT clear includes 2+ different types
+        // Combo bonus: apply +20 when the CURRENT clear includes 2+ different types
         const currentClearTypesCount = (clearedLines.rows.length > 0 ? 1 : 0)
             + (clearedLines.columns.length > 0 ? 1 : 0)
             + (clearedLines.squares.length > 0 ? 1 : 0);
         if (currentClearTypesCount >= 2) {
-            scoreGained += 25;
-            this.pointsBreakdown.comboBonusPoints += 25;
+            scoreGained += 20;
+            this.pointsBreakdown.comboBonusPoints += 20;
         }
         
         // Level multiplier


### PR DESCRIPTION
Update clear points for lines to 15, squares to 20, and adjust the combo bonus from +25 to +20.

---
<a href="https://cursor.com/background-agent?bcId=bc-a12054a3-45cf-4907-8224-763106b988b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a12054a3-45cf-4907-8224-763106b988b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

