### PR TITLE
Fix pwa install option on android

### DIFF
--- a/src/js/pwa/install.js
+++ b/src/js/pwa/install.js
@@ -29,6 +29,8 @@ export class PWAInstallManager {
             // Create and show install button immediately
             this.createInstallButton();
             this.showInstallButton();
+            // Ensure settings page status reflects availability
+            this.updateSettingsButtonStatus();
         });
         
         // Listen for the appinstalled event
@@ -253,7 +255,17 @@ export class PWAInstallManager {
         } else {
             this.settingsInstallButton.classList.remove('installed');
             if (statusElement) {
-                statusElement.textContent = 'Not available';
+                // Provide platform-specific guidance instead of a hard "Not available"
+                const ua = (navigator.userAgent || '').toLowerCase();
+                let message = '';
+                if (ua.includes('android')) {
+                    message = 'Install via browser menu';
+                } else if (/iphone|ipad|ipod/.test(ua)) {
+                    message = 'Use Share → Add to Home Screen';
+                } else {
+                    message = 'Install via browser menu';
+                }
+                statusElement.textContent = message;
             }
         }
     }


### PR DESCRIPTION
Refresh PWA install status on settings page and provide platform-specific install guidance.

The previous implementation showed "Not available" on the settings page even when PWA installation was possible via the browser menu on Android, and didn't update the status dynamically when the `beforeinstallprompt` event fired. This change ensures the status is updated and provides actionable instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-2d0b6694-0644-4a1b-8c93-193cfc5eabce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2d0b6694-0644-4a1b-8c93-193cfc5eabce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

