### PR TITLE
Dull shape color when dragging

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -754,6 +754,18 @@ body {
     box-shadow: 0 4px 15px rgba(0, 123, 255, 0.3);
 }
 
+/* Dragging state: dull color and subtle scale so users know it's being dragged */
+.block-item.dragging {
+    filter: saturate(60%) brightness(0.9);
+    opacity: 0.7;
+    transform: scale(1.05);
+    transition: filter 0.1s ease, opacity 0.1s ease, transform 0.1s ease;
+}
+
+.block-item.dragging .block-preview canvas {
+    filter: grayscale(30%);
+}
+
 @keyframes pulse {
     0% { box-shadow: 0 12px 35px rgba(0, 123, 255, 0.4); }
     50% { box-shadow: 0 12px 35px rgba(0, 123, 255, 0.6); }

--- a/src/js/ui/block-palette.js
+++ b/src/js/ui/block-palette.js
@@ -157,8 +157,7 @@ export class BlockPalette {
                         // Add dragging visual feedback
                         const blockItem = document.querySelector(`[data-block-id="${this.touchStartBlockId}"]`);
                         if (blockItem) {
-                            blockItem.style.opacity = '0.7';
-                            blockItem.style.transform = 'scale(1.1)';
+                            blockItem.classList.add('dragging');
                         }
                     }
                 }
@@ -170,9 +169,9 @@ export class BlockPalette {
                 // Reset visual feedback
                 const blockItem = document.querySelector(`[data-block-id="${this.touchStartBlockId}"]`);
                 if (blockItem) {
+                    blockItem.classList.remove('dragging');
                     blockItem.style.transform = '';
                     blockItem.style.transition = '';
-                    blockItem.style.opacity = '';
                 }
                 
                 this.touchStart = null;
@@ -187,9 +186,9 @@ export class BlockPalette {
                 // Reset visual feedback
                 const blockItem = document.querySelector(`[data-block-id="${this.touchStartBlockId}"]`);
                 if (blockItem) {
+                    blockItem.classList.remove('dragging');
                     blockItem.style.transform = '';
                     blockItem.style.transition = '';
-                    blockItem.style.opacity = '';
                 }
                 
                 this.touchStart = null;


### PR DESCRIPTION
Add a visual "dragging" state to block palette items to clearly indicate when a block is being dragged for preview.

---
<a href="https://cursor.com/background-agent?bcId=bc-8561c11a-b855-42be-9646-ff8f607726b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8561c11a-b855-42be-9646-ff8f607726b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

