### PR TITLE
Dim blue shapes for dark theme

### DIFF
--- a/css/themes/dark.css
+++ b/css/themes/dark.css
@@ -14,8 +14,8 @@
     --cell-bg: #0f0f0f;
     --cell-border: #333333;
     --cell-hover: #1a1a1a;
-    --block-color: #00d4ff;
-    --block-border: #0099cc;
+    --block-color: #00aacc;
+    --block-border: #007aa3;
     --grid-line: #333333;
     --highlight: #001a33;
 }

--- a/public/css/themes/dark.css
+++ b/public/css/themes/dark.css
@@ -14,8 +14,8 @@
     --cell-bg: #0f0f0f;
     --cell-border: #333333;
     --cell-hover: #1a1a1a;
-    --block-color: #00d4ff;
-    --block-border: #0099cc;
+    --block-color: #00aacc;
+    --block-border: #007aa3;
     --grid-line: #333333;
     --highlight: #001a33;
 }

--- a/src/css/themes/dark.css
+++ b/src/css/themes/dark.css
@@ -14,8 +14,8 @@
     --cell-bg: #0f0f0f;
     --cell-border: #333333;
     --cell-hover: #1a1a1a;
-    --block-color: #00d4ff;
-    --block-border: #0099cc;
+    --block-color: #00aacc;
+    --block-border: #007aa3;
     --grid-line: #333333;
     --highlight: #001a33;
 }


### PR DESCRIPTION
Reduce the brightness of the blue for placed shapes on the dark theme by approximately 20%.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ead526f-43c4-414e-b125-a25c1b2d1b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7ead526f-43c4-414e-b125-a25c1b2d1b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

