### PR TITLE
Add subtle clear indicators and update wood theme

### DIFF
--- a/src/css/themes/dark.css
+++ b/src/css/themes/dark.css
@@ -18,6 +18,7 @@
     --block-border: #0099cc;
     --grid-line: #333333;
     --highlight: #001a33;
+    --clear-glow-color: #ff4444;
 }
 
 /* Dark theme effects */

--- a/src/css/themes/light.css
+++ b/src/css/themes/light.css
@@ -18,4 +18,5 @@
     --block-border: #0056b3;
     --grid-line: #dee2e6;
     --highlight: #fff3cd;
+    --clear-glow-color: #00ff00;
 }

--- a/src/css/themes/wood.css
+++ b/src/css/themes/wood.css
@@ -20,6 +20,7 @@
     --highlight: #4e342e;
     --card-bg: #3d2a1a;
     --accent-color: #a1887f;
+    --clear-glow-color: #00aaff;
 }
 
 /* Wood texture effects */


### PR DESCRIPTION
Add subtle pre-clear indication for easy/normal difficulty and theme-specific clear glow colors.

The pre-clear indication provides a visual cue for potential line clears in easier difficulties. Glow colors are now theme-specific: wood theme glows blue, dark theme glows red, and light theme remains green, improving visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-28d7f971-6d89-4910-b2ad-01452b8f8e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28d7f971-6d89-4910-b2ad-01452b8f8e5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

