### PR TITLE
Fix combo counter accumulation and reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,10 @@
                         <span>Combo </span>
                         <span id="combo">0</span>
                     </div>
+                    <div class="combo-total">
+                        <span>Combos </span>
+                        <span id="combo-total">0</span>
+                    </div>
                     <div class="timer" id="timer-display" style="display: none;">
                         <span>TIME</span>
                         <span id="timer">5:00</span>

--- a/src/index.html
+++ b/src/index.html
@@ -64,6 +64,10 @@
                         <span>Combo </span>
                         <span id="combo">0</span>
                     </div>
+                    <div class="combo-total">
+                        <span>Combos </span>
+                        <span id="combo-total">0</span>
+                    </div>
                 </div>
                 
                 <div class="game-area">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1340,8 +1340,10 @@ class BlockdokuGame {
         const scoreElement = document.getElementById('score');
         const levelElement = document.getElementById('level');
         const comboElement = document.getElementById('combo');
+        const comboTotalElement = document.getElementById('combo-total');
         
         const currentCombo = this.scoringSystem.getCombo();
+        const totalCombos = this.scoringSystem.getComboTotal ? this.scoringSystem.getComboTotal() : this.scoringSystem.comboActivations || 0;
         
         // Check for first score gain
         if (this.previousScore === 0 && this.score > 0) {
@@ -1364,6 +1366,9 @@ class BlockdokuGame {
         scoreElement.textContent = this.score;
         levelElement.textContent = this.level;
         comboElement.textContent = currentCombo;
+        if (comboTotalElement) {
+            comboTotalElement.textContent = totalCombos;
+        }
         
         // Update previous values
         this.previousScore = this.score;

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1272,8 +1272,16 @@ class BlockdokuGame {
         const centerY = this.canvas.height / 2;
         this.effectsManager.onLineClear(centerX, centerY, clearedLines);
         
-        // Create score popup
-        this.createScorePopup(centerX, centerY, result.scoreGained);
+        // Create score popup with contextual details
+        this.createScorePopup(
+            centerX,
+            centerY,
+            result.scoreGained,
+            clearedLines,
+            result.isCombo,
+            combo,
+            (this.storage.loadSettings()?.comboDisplayMode) || 'streak'
+        );
         
         // Create combo effect if applicable
         if (combo > 1) {
@@ -1344,6 +1352,10 @@ class BlockdokuGame {
         
         const currentCombo = this.scoringSystem.getCombo();
         const totalCombos = this.scoringSystem.getComboTotal ? this.scoringSystem.getComboTotal() : this.scoringSystem.comboActivations || 0;
+
+        // Determine which value to show based on settings
+        const settings = this.storage.loadSettings();
+        const mode = settings.comboDisplayMode || 'streak';
         
         // Check for first score gain
         if (this.previousScore === 0 && this.score > 0) {
@@ -1365,9 +1377,15 @@ class BlockdokuGame {
         // Update the text content
         scoreElement.textContent = this.score;
         levelElement.textContent = this.level;
-        comboElement.textContent = currentCombo;
+        if (mode === 'cumulative') {
+            comboElement.textContent = totalCombos;
+        } else {
+            comboElement.textContent = currentCombo;
+        }
         if (comboTotalElement) {
             comboTotalElement.textContent = totalCombos;
+            // Optionally hide duplicate display if showing cumulative in main spot
+            comboTotalElement.parentElement.style.display = mode === 'cumulative' ? 'none' : '';
         }
         
         // Update previous values
@@ -1522,8 +1540,8 @@ class BlockdokuGame {
         }, 100);
     }
     
-    createScorePopup(x, y, scoreGained) {
-        // Enhanced score popup with better visibility
+    createScorePopup(x, y, scoreGained, clearedLines = { rows: [], columns: [], squares: [] }, isCombo = false, comboValue = 0, comboMode = 'streak') {
+        // Enhanced score popup with contextual visibility
         this.ctx.save();
         
         // Add background for better visibility
@@ -1535,11 +1553,25 @@ class BlockdokuGame {
         this.ctx.lineWidth = 2;
         this.ctx.strokeRect(x - 60, y - 20, 120, 40);
         
-        // Draw score text
+        // Build contextual text
+        const totalLines = (clearedLines?.rows?.length || 0) + (clearedLines?.columns?.length || 0);
+        const squares = (clearedLines?.squares?.length || 0);
+        const parts = [];
+        if (totalLines > 0) parts.push(`${totalLines} line${totalLines>1?'s':''}`);
+        if (squares > 0) parts.push(`${squares} square${squares>1?'s':''}`);
+        const contextText = parts.length ? parts.join(' + ') : 'Placement';
+
+        // Primary score text
         this.ctx.fillStyle = '#00ff00';
-        this.ctx.font = 'bold 28px Arial';
+        this.ctx.font = 'bold 22px Arial';
         this.ctx.textAlign = 'center';
-        this.ctx.fillText(`+${scoreGained}`, x, y + 8);
+        this.ctx.fillText(`+${scoreGained}`, x, y);
+
+        // Secondary context line
+        this.ctx.fillStyle = '#ffffff';
+        this.ctx.font = 'bold 14px Arial';
+        const comboLabel = isCombo ? (comboMode === 'cumulative' ? ` • COMBO x${comboValue} (total)` : ` • COMBO x${comboValue}`) : '';
+        this.ctx.fillText(`${contextText}${comboLabel}`, x, y + 18);
         
         this.ctx.restore();
         
@@ -1550,14 +1582,20 @@ class BlockdokuGame {
                 this.ctx.save();
                 this.ctx.globalAlpha = 1 - (animationFrame / 60);
                 this.ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
-                this.ctx.fillRect(x - 60, y - 20 - animationFrame * 2, 120, 40);
+                this.ctx.fillRect(x - 70, y - 24 - animationFrame * 2, 140, 48);
                 this.ctx.strokeStyle = '#00ff00';
                 this.ctx.lineWidth = 2;
-                this.ctx.strokeRect(x - 60, y - 20 - animationFrame * 2, 120, 40);
+                this.ctx.strokeRect(x - 70, y - 24 - animationFrame * 2, 140, 48);
                 this.ctx.fillStyle = '#00ff00';
-                this.ctx.font = 'bold 28px Arial';
+                this.ctx.font = 'bold 22px Arial';
                 this.ctx.textAlign = 'center';
-                this.ctx.fillText(`+${scoreGained}`, x, y + 8 - animationFrame * 2);
+                this.ctx.fillText(`+${scoreGained}`, x, y - 4 - animationFrame * 2);
+
+                // Draw secondary text
+                this.ctx.fillStyle = '#ffffff';
+                this.ctx.font = 'bold 14px Arial';
+                const comboLabelAnim = isCombo ? (comboMode === 'cumulative' ? ` • COMBO x${comboValue} (total)` : ` • COMBO x${comboValue}`) : '';
+                this.ctx.fillText(`${contextText}${comboLabelAnim}`, x, y + 14 - animationFrame * 2);
                 this.ctx.restore();
                 
                 animationFrame++;

--- a/src/js/game/scoring.js
+++ b/src/js/game/scoring.js
@@ -242,6 +242,11 @@ export class ScoringSystem {
         return this.maxCombo;
     }
     
+    // Total number of times a combo has been activated during the current game
+    getComboTotal() {
+        return this.comboActivations;
+    }
+    
     getLinesCleared() {
         return this.linesCleared;
     }

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -97,6 +97,13 @@ class SettingsManager {
         if (showHighScore) {
             showHighScore.checked = this.settings.showHighScore === true; // Default to false
         }
+
+        // Combo display mode
+        const comboMode = document.getElementById('combo-display-mode');
+        if (comboMode) {
+            const mode = this.settings.comboDisplayMode || 'streak';
+            comboMode.value = mode;
+        }
     }
     
     setupEventListeners() {
@@ -171,6 +178,14 @@ class SettingsManager {
         if (showHighScore) {
             showHighScore.addEventListener('change', (e) => {
                 this.updateSetting('showHighScore', e.target.checked);
+            });
+        }
+
+        const comboMode = document.getElementById('combo-display-mode');
+        if (comboMode) {
+            comboMode.addEventListener('change', (e) => {
+                const value = e.target.value === 'cumulative' ? 'cumulative' : 'streak';
+                this.updateSetting('comboDisplayMode', value);
             });
         }
         

--- a/src/js/storage/game-storage.js
+++ b/src/js/storage/game-storage.js
@@ -148,7 +148,8 @@ export class GameStorage {
             enableTimer: false,
             enableUndo: false,
             showPoints: false,
-            showHighScore: false
+            showHighScore: false,
+            comboDisplayMode: 'streak' // 'streak' or 'cumulative'
         };
     }
 

--- a/src/settings.html
+++ b/src/settings.html
@@ -349,6 +349,15 @@
                 <h2 class="section-title">Game Settings</h2>
                 <div class="setting-item">
                     <label>
+                        <span>Combo display</span>
+                        <select id="combo-display-mode">
+                            <option value="streak">Streak</option>
+                            <option value="cumulative">Cumulative</option>
+                        </select>
+                    </label>
+                </div>
+                <div class="setting-item">
+                    <label>
                         <input type="checkbox" id="enable-hints" />
                         Enable hints
                     </label>


### PR DESCRIPTION
Add a cumulative combo counter and display to differentiate from the existing combo streak.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe04f581-ef65-46d3-86f1-5e7b8282286d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe04f581-ef65-46d3-86f1-5e7b8282286d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

