### PR TITLE
Fix combo display and add counting setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,12 +47,8 @@
                         <span id="level">1</span>
                     </div>
                     <div class="combo">
-                        <span>Combo </span>
+                        <span id="combo-label">Combo</span>
                         <span id="combo">0</span>
-                    </div>
-                    <div class="combo-total">
-                        <span>Combos </span>
-                        <span id="combo-total">0</span>
                     </div>
                     <div class="timer" id="timer-display" style="display: none;">
                         <span>TIME</span>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1424,12 +1424,12 @@ class BlockdokuGame {
         // Update the text content
         scoreElement.textContent = this.score;
         levelElement.textContent = this.level;
+        // Always show label as singular 'Combo', switch value per mode
+        if (comboLabelElement) comboLabelElement.textContent = 'Combo';
         if (mode === 'cumulative') {
             comboElement.textContent = totalCombos;
-            if (comboLabelElement) comboLabelElement.textContent = 'Combos ';
         } else {
             comboElement.textContent = currentCombo;
-            if (comboLabelElement) comboLabelElement.textContent = 'Combo ';
         }
         
         // Update previous values


### PR DESCRIPTION
Standardize the scoring bar's combo label to 'Combo' and remove the duplicate 'Combos' display.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7dcb7c4-1830-4495-a115-8eb784e0dda2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f7dcb7c4-1830-4495-a115-8eb784e0dda2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

