### PR TITLE
Center copyright at bottom of settings

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -257,6 +257,23 @@
             }
         }
     </style>
+    <style>
+        /* Settings page copyright override */
+        .copyright-notice {
+            position: static;
+            bottom: auto;
+            right: auto;
+            pointer-events: none;
+            margin: 2rem 0 0;
+            text-align: center;
+            width: 100%;
+        }
+        .copyright-notice p {
+            background: none;
+            color: var(--text-muted);
+            text-shadow: none;
+        }
+    </style>
   <script type="module" crossorigin src="./assets/settings-AbriGX7E.js"></script>
   <link rel="modulepreload" crossorigin href="./assets/wood-CS1vos5M.js">
   <link rel="modulepreload" crossorigin href="./assets/confirmation-dialog-oQSc4aXZ.js">

--- a/src/settings.html
+++ b/src/settings.html
@@ -258,6 +258,31 @@
                 padding: 1.5rem;
             }
         }
+        /* Settings page layout/footer override */
+        body {
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+        .settings-container {
+            flex: 1;
+            min-height: 0;
+        }
+        /* Settings page copyright override */
+        .copyright-notice {
+            position: static;
+            bottom: auto;
+            right: auto;
+            pointer-events: none;
+            margin: 2rem 0 0;
+            text-align: center;
+            width: 100%;
+        }
+        .copyright-notice p {
+            background: none;
+            color: var(--text-muted);
+            text-shadow: none;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
Update the settings page copyright notice to be static, centered, and positioned at the bottom.

---
<a href="https://cursor.com/background-agent?bcId=bc-91b1801e-2145-4c60-a716-c2facefddcdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91b1801e-2145-4c60-a716-c2facefddcdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

