### PR TITLE
Implement theme-driven line clear feedback

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1240,12 +1240,13 @@ class BlockdokuGame {
         this.ctx.fillRect(x - 80, y - 20, 160, 40);
         
         // Draw border
-        this.ctx.strokeStyle = '#00ff00';
+        const notifGlow = this.getClearGlowColor();
+        this.ctx.strokeStyle = notifGlow;
         this.ctx.lineWidth = 3;
         this.ctx.strokeRect(x - 80, y - 20, 160, 40);
         
         // Draw text
-        this.ctx.fillStyle = '#00ff00';
+        this.ctx.fillStyle = notifGlow;
         this.ctx.font = 'bold 24px Arial';
         this.ctx.textAlign = 'center';
         this.ctx.fillText(message, x, y + 8);

--- a/src/js/effects/effects-manager.js
+++ b/src/js/effects/effects-manager.js
@@ -95,8 +95,9 @@ export class EffectsManager {
     }
     
     // Glow trail for block movement
-    onBlockMove(x, y, color = '#00ff00') {
-        this.particles.createGlowTrail(x, y, color);
+    onBlockMove(x, y, color = null) {
+        const themeColor = color || getComputedStyle(document.documentElement).getPropertyValue('--clear-glow-color').trim() || '#00ff00';
+        this.particles.createGlowTrail(x, y, themeColor);
     }
     
     // Update all effects


### PR DESCRIPTION
Make all immediate clear feedback theme-driven by replacing hardcoded green with theme glow color.

Previously, the quick clear notification and block movement glow trail used a hardcoded green color, preventing them from adapting to the selected theme. This change ensures consistency with the theme-driven clear glow colors (blue for wood, red for dark, green for light).

---
<a href="https://cursor.com/background-agent?bcId=bc-231b4857-09d3-44b9-a1ce-5eba4b1d5331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-231b4857-09d3-44b9-a1ce-5eba4b1d5331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

