### PR TITLE
Persist board state through settings navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blockdoku-pwa",
-  "version": "0.1.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blockdoku-pwa",
-      "version": "0.1.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "workbox-window": "^7.0.0"

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -190,7 +190,7 @@ class BlockdokuGame {
         this.setupEventListeners();
         this.registerServiceWorker();
         // this.loadSettings();
-        // this.loadGameState();
+        this.loadGameState();
         this.generateNewBlocks();
         
         // Initialize timer system for current difficulty
@@ -461,6 +461,22 @@ class BlockdokuGame {
             if (e.key === 'blockdoku-settings' || e.key === 'blockdoku_settings') {
                 this.loadSettings();
                 this.updateHintControls();
+            }
+        });
+        
+        // Save game state when navigating away from the page
+        window.addEventListener('beforeunload', () => {
+            console.log('beforeunload event triggered, autoSave:', this.autoSave, 'isGameOver:', this.isGameOver);
+            if (this.autoSave && !this.isGameOver) {
+                this.saveGameState();
+            }
+        });
+        
+        // Save game state when page becomes hidden (e.g., navigating to settings)
+        document.addEventListener('visibilitychange', () => {
+            console.log('visibilitychange event triggered, hidden:', document.hidden, 'autoSave:', this.autoSave, 'isGameOver:', this.isGameOver);
+            if (document.hidden && this.autoSave && !this.isGameOver) {
+                this.saveGameState();
             }
         });
     }
@@ -1839,6 +1855,7 @@ class BlockdokuGame {
     loadGameState() {
         const savedState = this.storage.loadGameState();
         if (savedState) {
+            console.log('Loading saved game state:', savedState);
             this.board = savedState.board || this.initializeBoard();
             this.score = savedState.score || 0;
             this.level = savedState.level || 1;
@@ -1853,6 +1870,9 @@ class BlockdokuGame {
             if (savedState.selectedBlock) {
                 this.selectedBlock = savedState.selectedBlock;
             }
+            console.log('Game state loaded successfully');
+        } else {
+            console.log('No saved game state found');
         }
     }
 
@@ -1864,7 +1884,9 @@ class BlockdokuGame {
             currentBlocks: this.blockManager.currentBlocks,
             selectedBlock: this.selectedBlock
         };
+        console.log('Saving game state:', gameState);
         this.storage.saveGameState(gameState);
+        console.log('Game state saved successfully');
     }
 
     loadSettings() {


### PR DESCRIPTION
Enable game state persistence across page navigations by ensuring state is loaded on init and saved on page hide/unload.

The `loadGameState()` call was commented out, preventing restoration of saved progress. Additionally, there were no explicit mechanisms to save the game state when the user navigated away from the main game page (e.g., to the settings page), leading to data loss. This PR activates the loading of saved state and adds event listeners to automatically save the game state when the page becomes hidden or is about to unload.

---
<a href="https://cursor.com/background-agent?bcId=bc-f842e886-1251-40e3-aa91-4e5b3b0032de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f842e886-1251-40e3-aa91-4e5b3b0032de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

