### PR TITLE
Style combo box and reset button

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -378,11 +378,14 @@
                 <h2 class="section-title">Game Settings</h2>
                 <div class="setting-item">
                     <label>
-                        <span>Combo display</span>
-                        <select id="combo-display-mode">
-                            <option value="streak">Streak</option>
-                            <option value="cumulative">Cumulative</option>
-                        </select>
+                        <input type="radio" name="combo-display-mode" value="streak" id="combo-streak" />
+                        <span>Combo display: Streak</span>
+                    </label>
+                </div>
+                <div class="setting-item">
+                    <label>
+                        <input type="radio" name="combo-display-mode" value="cumulative" id="combo-cumulative" />
+                        <span>Combo display: Cumulative</span>
                     </label>
                 </div>
                 <div class="setting-item">
@@ -439,15 +442,18 @@
                         Show block points
                     </label>
                 </div>
-                <div class="setting-item">
-                    <button id="reset-stats" class="danger-button">Reset statistics</button>
-                </div>
-                
                 <!-- PWA Install Button -->
                 <div class="setting-item pwa-install-item">
                     <button id="pwa-install-button" class="pwa-install-button">
                         <span class="install-text">Install as PWA</span>
                         <span class="install-status" id="install-status"></span>
+                    </button>
+                </div>
+                
+                <!-- Reset Statistics Button -->
+                <div class="setting-item reset-stats-item">
+                    <button id="reset-stats" class="reset-stats-button">
+                        <span class="reset-text">Reset Statistics</span>
                     </button>
                 </div>
             </div>

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1812,7 +1812,8 @@ html.light-theme .settings-section .difficulty-option.selected {
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7) !important;
 }
 
-.setting-item input[type="checkbox"] {
+.setting-item input[type="checkbox"],
+.setting-item input[type="radio"] {
     margin-right: 0.75rem;
     width: 18px;
     height: 18px;
@@ -2063,6 +2064,13 @@ html.light-theme .settings-section .difficulty-option.selected {
     border-top: 1px solid var(--border-color);
 }
 
+/* Reset Statistics Button Styles */
+.reset-stats-item {
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border-color);
+}
+
 .pwa-install-button {
     background: linear-gradient(135deg, var(--primary-color) 0%, var(--primary-hover) 100%);
     color: white;
@@ -2114,6 +2122,38 @@ html.light-theme .settings-section .difficulty-option.selected {
 .pwa-install-button.installed .install-status::before {
     content: "✓ ";
     margin-right: 0.25rem;
+}
+
+.reset-stats-button {
+    background: linear-gradient(135deg, #dc3545 0%, #c82333 100%);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+    box-shadow: 0 2px 8px rgba(220, 53, 69, 0.15);
+}
+
+.reset-stats-button:hover {
+    background: linear-gradient(135deg, #c82333 0%, #bd2130 100%);
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(220, 53, 69, 0.2);
+}
+
+.reset-stats-button:active {
+    transform: translateY(0);
+}
+
+.reset-text {
+    font-weight: 600;
 }
 
 /* Copyright Notice */

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -100,11 +100,16 @@ class SettingsManager {
             showHighScore.checked = this.settings.showHighScore === true; // Default to false
         }
 
-        // Combo display mode
-        const comboMode = document.getElementById('combo-display-mode');
-        if (comboMode) {
+        // Combo display mode - handle radio buttons
+        const comboStreak = document.getElementById('combo-streak');
+        const comboCumulative = document.getElementById('combo-cumulative');
+        if (comboStreak && comboCumulative) {
             const mode = this.settings.comboDisplayMode || 'streak';
-            comboMode.value = mode;
+            if (mode === 'cumulative') {
+                comboCumulative.checked = true;
+            } else {
+                comboStreak.checked = true;
+            }
         }
     }
     
@@ -183,11 +188,19 @@ class SettingsManager {
             });
         }
 
-        const comboMode = document.getElementById('combo-display-mode');
-        if (comboMode) {
-            comboMode.addEventListener('change', (e) => {
-                const value = e.target.value === 'cumulative' ? 'cumulative' : 'streak';
-                this.updateSetting('comboDisplayMode', value);
+        // Combo display mode - handle radio buttons
+        const comboStreak = document.getElementById('combo-streak');
+        const comboCumulative = document.getElementById('combo-cumulative');
+        if (comboStreak && comboCumulative) {
+            comboStreak.addEventListener('change', (e) => {
+                if (e.target.checked) {
+                    this.updateSetting('comboDisplayMode', 'streak');
+                }
+            });
+            comboCumulative.addEventListener('change', (e) => {
+                if (e.target.checked) {
+                    this.updateSetting('comboDisplayMode', 'cumulative');
+                }
             });
         }
         

--- a/src/settings.html
+++ b/src/settings.html
@@ -374,11 +374,14 @@
                 <h2 class="section-title">Game Settings</h2>
                 <div class="setting-item">
                     <label>
-                        <span>Combo display</span>
-                        <select id="combo-display-mode">
-                            <option value="streak">Streak</option>
-                            <option value="cumulative">Cumulative</option>
-                        </select>
+                        <input type="radio" name="combo-display-mode" value="streak" id="combo-streak" />
+                        <span>Combo display: Streak</span>
+                    </label>
+                </div>
+                <div class="setting-item">
+                    <label>
+                        <input type="radio" name="combo-display-mode" value="cumulative" id="combo-cumulative" />
+                        <span>Combo display: Cumulative</span>
                     </label>
                 </div>
                 <div class="setting-item">
@@ -435,15 +438,18 @@
                         Show block points
                     </label>
                 </div>
-                <div class="setting-item">
-                    <button id="reset-stats" class="danger-button">Reset statistics</button>
-                </div>
-                
                 <!-- PWA Install Button -->
                 <div class="setting-item pwa-install-item">
                     <button id="pwa-install-button" class="pwa-install-button">
                         <span class="install-text">Install as PWA</span>
                         <span class="install-status" id="install-status"></span>
+                    </button>
+                </div>
+                
+                <!-- Reset Statistics Button -->
+                <div class="setting-item reset-stats-item">
+                    <button id="reset-stats" class="reset-stats-button">
+                        <span class="reset-text">Reset Statistics</span>
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
Convert "Combo display" dropdown to radio buttons and restyle "Reset statistics" button to match PWA install button.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef6aeb2e-f4bc-4272-9b58-9c193e780f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef6aeb2e-f4bc-4272-9b58-9c193e780f5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

