### PR TITLE
Fix grayed out piece update logic

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -871,6 +871,8 @@ class BlockdokuGame {
         if (!this.board) {
             console.error('canPlaceBlock: Board is undefined! Reinitializing...');
             this.board = this.initializeBoard();
+            // Update placeability indicators after emergency board reinitialization
+            this.updatePlaceabilityIndicators();
         }
         
         return this.blockManager.canPlaceBlock(this.selectedBlock, row, col, this.board);
@@ -964,6 +966,8 @@ class BlockdokuGame {
                 console.error('FATAL: Could not initialize board in drawBoard');
                 return;
             }
+            // Update placeability indicators after emergency board reinitialization
+            this.updatePlaceabilityIndicators();
         }
         
         ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--block-color');
@@ -1353,6 +1357,9 @@ class BlockdokuGame {
         // Update UI
         this.updateUI();
         
+        // Update placeability indicators immediately after line clears
+        this.updatePlaceabilityIndicators();
+        
         // Check for additional line clears after this one
         setTimeout(() => {
             this.checkLineClears();
@@ -1375,6 +1382,9 @@ class BlockdokuGame {
         this.isInitialized = true;
         this.comboModeActive = 'streak';
         this.comboModesUsed = new Set();
+        
+        // Update placeability indicators for new game
+        this.updatePlaceabilityIndicators();
         
         // Reset animation tracking
         this.previousScore = 0;
@@ -1874,6 +1884,10 @@ class BlockdokuGame {
             if (savedState.selectedBlock) {
                 this.selectedBlock = savedState.selectedBlock;
             }
+            
+            // Update placeability indicators after loading game state
+            this.updatePlaceabilityIndicators();
+            
             console.log('Game state loaded successfully');
         } else {
             console.log('No saved game state found');
@@ -2595,6 +2609,9 @@ class BlockdokuGame {
         this.drawBoard();
         this.updateUI();
         
+        // Update placeability indicators immediately after block placement
+        this.updatePlaceabilityIndicators();
+        
         // Check for line clears
         this.checkLineClears();
         
@@ -2623,6 +2640,8 @@ class BlockdokuGame {
         if (!this.board) {
             console.error('EMERGENCY: Board is undefined in checkGameOver, reinitializing...');
             this.board = this.initializeBoard();
+            // Update placeability indicators after emergency board reinitialization
+            this.updatePlaceabilityIndicators();
         }
         
         // Don't check for game over during initialization or if game is already over


### PR DESCRIPTION
Update placeability indicators immediately after board state changes to fix incorrect graying out of pieces.

The `updatePlaceabilityIndicators()` method was only called in the main game loop's `update()` function. This caused a delay in visual feedback when the board state changed, such as after placing a block or clearing lines. Pieces that should have become placeable (un-grayed) after a line clear would remain grayed out until the next game loop tick. This PR ensures that the indicators are updated synchronously with board modifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-423f650f-8df5-419d-81ef-24736ec53fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-423f650f-8df5-419d-81ef-24736ec53fc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

