### PR TITLE
Fix score update timing on block clear

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2709,10 +2709,10 @@ class BlockdokuGame {
         
         // Score will be updated when lines are cleared, not on placement
         
-        // Update UI
+        // Update UI (but not score-related elements since score hasn't changed yet)
         this.blockPalette.updateBlocks(this.blockManager.currentBlocks);
         this.drawBoard();
-        this.updateUI();
+        // Don't call updateUI() here since score hasn't changed yet - let line clear handle it
         
         // Update placeability indicators immediately after block placement
         this.updatePlaceabilityIndicators();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2707,13 +2707,7 @@ class BlockdokuGame {
         this.selectedBlock = null;
         this.previewPosition = null;
         
-        // Update score/level immediately after placement points
-        {
-            const baseScore = this.scoringSystem.getScore();
-            const combo = this.scoringSystem.getCombo();
-            this.score = this.difficultyManager.calculateScore(baseScore, combo);
-            this.level = this.scoringSystem.getLevel();
-        }
+        // Score will be updated when lines are cleared, not on placement
         
         // Update UI
         this.blockPalette.updateBlocks(this.blockManager.currentBlocks);


### PR DESCRIPTION
Remove premature score update from `placeBlock` method.

The score was incorrectly updating immediately after a block was placed, instead of only when lines were cleared. This change ensures the score is updated solely in `completeLineClear` after lines are successfully cleared.

---
<a href="https://cursor.com/background-agent?bcId=bc-bcde4e82-955a-4681-b110-983252f99800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bcde4e82-955a-4681-b110-983252f99800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

