### PR TITLE
Fix w column combo bug

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1417,7 +1417,7 @@ class BlockdokuGame {
         );
         
         // Create combo effect if applicable
-        if (combo > 1) {
+        if (combo >= 1) {
             this.createComboEffect(combo, centerX, centerY + 50);
             this.effectsManager.onCombo(centerX, centerY + 50, combo);
         }
@@ -1513,7 +1513,7 @@ class BlockdokuGame {
         }
         
         // Check for combo hit
-        if (currentCombo > this.previousCombo && currentCombo > 1) {
+        if (currentCombo > this.previousCombo && currentCombo >= 1) {
             this.animateComboHit(comboElement);
         }
         

--- a/src/js/effects/haptic-feedback.js
+++ b/src/js/effects/haptic-feedback.js
@@ -96,7 +96,7 @@ export class HapticFeedback {
     
     // Combo feedback
     onCombo(combo) {
-        if (combo > 1) {
+        if (combo >= 1) {
             this.vibrate('combo');
         }
     }


### PR DESCRIPTION
Fix combo animation, visual effects, and haptic feedback to trigger on the first combo.

The previous logic only triggered these effects when the combo count was greater than 1, meaning the initial combo (from 0 to 1) provided no visual or haptic feedback to the user. This change ensures that all combos are properly acknowledged.

---
<a href="https://cursor.com/background-agent?bcId=bc-14052a4f-200f-497e-9aa4-688aa523c0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-14052a4f-200f-497e-9aa4-688aa523c0d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

