### PR TITLE
Fix score not updating after block clear

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1379,14 +1379,22 @@ class BlockdokuGame {
             
             // Actually clear the lines
             console.log('Applying clears to board...');
+            const previousScore = this.scoringSystem.getScore();
             result = this.scoringSystem.applyClears(this.board, clearedLines);
             console.log('Clears applied, result:', result);
             this.board = result.board;
             
             // Update score and level with difficulty multiplier
             const baseScore = this.scoringSystem.getScore();
+            const newlyGainedScore = baseScore - previousScore;
+            const difficultyMultiplier = this.difficultyManager.getScoreMultiplier();
+            const adjustedNewScore = Math.floor(newlyGainedScore * difficultyMultiplier);
+            this.score = this.score + adjustedNewScore;
+            
+            // Synchronize the scoring system with our adjusted score
+            this.scoringSystem.score = this.score;
+            
             combo = this.scoringSystem.getCombo();
-            this.score = this.difficultyManager.calculateScore(baseScore, combo);
             this.level = this.scoringSystem.getLevel();
             
             console.log('Line clear completed successfully. New score:', this.score, 'New level:', this.level);


### PR DESCRIPTION
Refactor score calculation to correctly apply the difficulty multiplier only to newly gained points and synchronize the `ScoringSystem` score, fixing incorrect score updates after block clears.

The previous implementation in `completeLineClear` was applying the difficulty multiplier to the `ScoringSystem`'s total score, which had already been updated, instead of just the points earned from the current line clear. This resulted in an incorrect final score. The fix calculates the newly gained score, applies the difficulty multiplier to it, and then adds it to the existing score, also ensuring the `ScoringSystem`'s internal score is synchronized.

---
<a href="https://cursor.com/background-agent?bcId=bc-866fd7cd-43a9-4e4c-bc5d-33bee15b06ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-866fd7cd-43a9-4e4c-bc5d-33bee15b06ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

