### PR TITLE
Debug streak combo mode not showing 1

### DIFF
--- a/src/js/game/scoring.js
+++ b/src/js/game/scoring.js
@@ -162,7 +162,7 @@ export class ScoringSystem {
             this.columnsClearedCount += clearedLines.columns.length;
             this.squaresClearedCount += clearedLines.squares.length;
 
-            this.calculateScore(clearedLines);
+            this.calculateScore(clearedLines, isComboEvent);
             this.linesCleared += totalCleared;
             
 			// A combo occurs when 2+ total clears happen in the same clear event
@@ -187,7 +187,7 @@ export class ScoringSystem {
         };
     }
     
-    calculateScore(clearedLines) {
+    calculateScore(clearedLines, isComboEvent = false) {
         let scoreGained = 0;
         
         // Base score for each type of clear


### PR DESCRIPTION
Fix combo counter not incrementing by passing `isComboEvent` to `calculateScore`.

The `isComboEvent` variable, which determines if a combo occurred, was defined in `applyClears` but not passed to `calculateScore`. This meant the combo bonus logic inside `calculateScore` was not correctly triggered, leading to the combo counter not incrementing as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-667aeab0-eecf-4e6b-8002-ffe95a5bb85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-667aeab0-eecf-4e6b-8002-ffe95a5bb85e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

