### PR TITLE
Style combo display in game settings

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1867,10 +1867,7 @@ html.light-theme .settings-section .difficulty-option.selected {
 }
 
 .combo-option input[type="radio"] {
-    margin-right: 0.5rem;
-    width: 16px;
-    height: 16px;
-    accent-color: var(--primary-color);
+    display: none;
 }
 
 .combo-option:has(input:checked) {


### PR DESCRIPTION
Hide radio button circles for combo display options and center their text for a cleaner UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-856be32c-313c-4496-b94c-759e249d97b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-856be32c-313c-4496-b94c-759e249d97b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

