### PR TITLE
Fix block selection drag behavior

### DIFF
--- a/src/js/ui/block-palette.js
+++ b/src/js/ui/block-palette.js
@@ -221,10 +221,17 @@ export class BlockPalette {
     }
     
     startDragFromPalette(touch) {
+        // Get the block that's actually being dragged
+        const draggedBlock = this.blockManager.getBlockById(this.touchStartBlockId);
+        if (!draggedBlock) return;
+        
+        // Auto-select the block being dragged
+        this.selectBlock(this.touchStartBlockId);
+        
         // Notify the game that we're starting a drag from the palette
         const dragEvent = new CustomEvent('blockDragStart', {
             detail: {
-                block: this.selectedBlock,
+                block: draggedBlock,
                 touch: touch
             }
         });


### PR DESCRIPTION
Fix bug where dragging a non-selected block from the palette would drag the previously selected block, by ensuring the dragged block is correctly identified and selected.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4b673ff-a298-4ed5-8c98-5bd044b9dbe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4b673ff-a298-4ed5-8c98-5bd044b9dbe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

