### PR TITLE
Set combo counting to cumulative by default

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -82,7 +82,7 @@ class BlockdokuGame {
         this.isInitialized = false;
         
         // Track combo display mode usage within a game (streak vs cumulative)
-        this.comboModeActive = 'streak';
+        this.comboModeActive = 'cumulative';
         this.comboModesUsed = new Set();
         
         // Drag and drop state
@@ -1497,7 +1497,7 @@ class BlockdokuGame {
             clearedLines,
             isCombo,
             combo,
-            (this.storage.loadSettings()?.comboDisplayMode) || 'streak'
+            (this.storage.loadSettings()?.comboDisplayMode) || 'cumulative'
         );
         
         // Create combo effect if applicable
@@ -1580,7 +1580,7 @@ class BlockdokuGame {
 
         // Determine which value to show based on settings
         const settings = this.storage.loadSettings();
-        const mode = settings.comboDisplayMode || 'streak';
+        const mode = settings.comboDisplayMode || 'cumulative';
         this.comboModeActive = mode;
         this.comboModesUsed.add(mode);
         
@@ -2446,8 +2446,8 @@ class BlockdokuGame {
 
         // Build combo summary based on which modes were used
         const modesUsedSet = new Set(stats.comboModesUsed || []);
-        const usedStreak = modesUsedSet.has('streak') || modesUsedSet.size === 0; // default to streak if unknown
-        const usedCumulative = modesUsedSet.has('cumulative');
+        const usedStreak = modesUsedSet.has('streak');
+        const usedCumulative = modesUsedSet.has('cumulative') || modesUsedSet.size === 0; // default to cumulative if unknown
         const comboSummary = usedStreak && usedCumulative
             ? `<p style=\"margin: 5px 0;\">Max Streak: ${stats.maxCombo}</p><p style=\"margin: 5px 0;\">Total Combos: ${stats.comboActivations || 0}</p>`
             : (usedCumulative

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -112,7 +112,7 @@ class SettingsManager {
         const comboStreak = document.getElementById('combo-streak');
         const comboCumulative = document.getElementById('combo-cumulative');
         if (comboStreak && comboCumulative) {
-            const mode = this.settings.comboDisplayMode || 'streak';
+            const mode = this.settings.comboDisplayMode || 'cumulative';
             if (mode === 'cumulative') {
                 comboCumulative.checked = true;
             } else {

--- a/src/js/storage/game-storage.js
+++ b/src/js/storage/game-storage.js
@@ -149,7 +149,7 @@ export class GameStorage {
             enableUndo: false,
             showPoints: false,
             showHighScore: false,
-            comboDisplayMode: 'streak' // 'streak' or 'cumulative'
+            comboDisplayMode: 'cumulative' // 'streak' or 'cumulative'
         };
     }
 

--- a/src/settings.html
+++ b/src/settings.html
@@ -527,7 +527,7 @@
                             <span class="combo-label">Streak</span>
                         </label>
                         <label class="combo-option">
-                            <input type="radio" name="combo-display-mode" value="cumulative" id="combo-cumulative" />
+                            <input type="radio" name="combo-display-mode" value="cumulative" id="combo-cumulative" checked />
                             <span class="combo-label">Cumulative</span>
                         </label>
                     </div>


### PR DESCRIPTION
Set default combo counting mode to cumulative to align with user preference and improve the default game experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-ac7b658a-8af3-4c68-8019-a96caaa51fea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ac7b658a-8af3-4c68-8019-a96caaa51fea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

