### PR TITLE
Update about settings with source code links

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -614,16 +614,10 @@
                     </div>
                     
                     <div class="about-item">
-                        <h3>License</h3>
-                        <p>This project is licensed under the <strong>GNU Affero General Public License v3.0</strong></p>
-                        <p>The AGPL-3.0 is a strong copyleft license that requires anyone who distributes the software or provides it as a service to also make the source code available under the same license.</p>
-                        <p><a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener noreferrer">View full license text</a></p>
-                    </div>
-                    
-                    <div class="about-item">
                         <h3>Source Code</h3>
                         <p>This is a Progressive Web App (PWA) built with modern web technologies including Vite, vanilla JavaScript, and CSS3.</p>
-                        <p>The source code is available and open for contribution under the AGPL-3.0 license.</p>
+                        <p>The source code is available and open for contribution under the <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener noreferrer">AGPL-3.0 license</a>.</p>
+                        <p><a href="https://github.com/chasepettet/blockdoku" target="_blank" rel="noopener noreferrer">View on GitHub</a></p>
                     </div>
                     
                     <div class="about-item">

--- a/src/settings.html
+++ b/src/settings.html
@@ -641,16 +641,10 @@
                     </div>
                     
                     <div class="about-item">
-                        <h3>License</h3>
-                        <p>This project is licensed under the <strong>GNU Affero General Public License v3.0</strong></p>
-                        <p>The AGPL-3.0 is a strong copyleft license that requires anyone who distributes the software or provides it as a service to also make the source code available under the same license.</p>
-                        <p><a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener noreferrer">View full license text</a></p>
-                    </div>
-                    
-                    <div class="about-item">
                         <h3>Source Code</h3>
                         <p>This is a Progressive Web App (PWA) built with modern web technologies including Vite, vanilla JavaScript, and CSS3.</p>
-                        <p>The source code is available and open for contribution under the AGPL-3.0 license.</p>
+                        <p>The source code is available and open for contribution under the <a href="https://www.gnu.org/licenses/agpl-3.0.html" target="_blank" rel="noopener noreferrer">AGPL-3.0 license</a>.</p>
+                        <p><a href="https://github.com/chasepettet/blockdoku" target="_blank" rel="noopener noreferrer">View on GitHub</a></p>
                     </div>
                     
                     <div class="about-item">


### PR DESCRIPTION
Remove the dedicated license section from the about page, make the AGPL-3.0 reference a link, and add a GitHub project link to streamline the information.

---
<a href="https://cursor.com/background-agent?bcId=bc-da2d66c5-f618-445f-821b-0c2a11b90eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da2d66c5-f618-445f-821b-0c2a11b90eee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

