### PR TITLE
Verify game over score calculations

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1189,15 +1189,8 @@ class BlockdokuGame {
                 this.scoringSystem.combo = 0;
             }
             
-            // Update points breakdown
-            const linePointsAdded = (clearedLines.rows.length + clearedLines.columns.length) * this.scoringSystem.basePoints.line;
-            const squarePointsAdded = clearedLines.squares.length * this.scoringSystem.basePoints.square;
-            this.scoringSystem.pointsBreakdown.linePoints += linePointsAdded;
-            this.scoringSystem.pointsBreakdown.squarePoints += squarePointsAdded;
-            if (scoreInfo.isComboEvent) {
-                const comboBonus = 20 * (totalClears - 1);
-                this.scoringSystem.pointsBreakdown.comboBonusPoints += comboBonus;
-            }
+            // Points breakdown is now handled by the ScoringSystem.calculateScore method
+            // No need to duplicate the logic here
         }
         
         // Store the result for later use in completeLineClear
@@ -2454,7 +2447,7 @@ class BlockdokuGame {
 		// Build detailed stats and breakdown
 		const difficultyLabel = (stats.difficulty?.toUpperCase?.() || this.difficulty.toUpperCase());
 		const multiplier = stats.difficultyMultiplier || (this.difficultyManager?.getScoreMultiplier?.() || 1);
-		const breakdown = stats.breakdown || { linePoints: 0, squarePoints: 0, comboBonusPoints: 0 };
+		const breakdown = stats.breakdown || { linePoints: 0, squarePoints: 0, comboBonusPoints: 0, placementPoints: 0 };
 		const clears = {
 			rows: stats.rowClears || 0,
 			columns: stats.columnClears || 0,
@@ -2486,7 +2479,9 @@ class BlockdokuGame {
 						<h3 style=\"margin: 0 0 6px 0; color: var(--primary-color, #3498db); font-size: 1em;\">Score Breakdown</h3>
 						<p style=\"margin: 4px 0;\">Lines: <strong>${breakdown.linePoints.toLocaleString()}</strong></p>
 						<p style=\"margin: 4px 0;\">Squares: <strong>${breakdown.squarePoints.toLocaleString()}</strong></p>
+						<p style=\"margin: 4px 0;\">Placements: <strong>${breakdown.placementPoints.toLocaleString()}</strong></p>
 						<p style=\"margin: 4px 0;\">Combo Bonus: <strong>${breakdown.comboBonusPoints.toLocaleString()}</strong></p>
+						<p style=\"margin: 8px 0 4px 0; padding-top: 4px; border-top: 1px solid rgba(255,255,255,0.2); font-weight: bold; color: var(--primary-color, #3498db);">Total: <strong>${(breakdown.linePoints + breakdown.squarePoints + breakdown.placementPoints + breakdown.comboBonusPoints).toLocaleString()}</strong></p>
 					</div>
 				</div>
 			</div>

--- a/src/js/game/scoring.js
+++ b/src/js/game/scoring.js
@@ -23,7 +23,8 @@ export class ScoringSystem {
         this.pointsBreakdown = {
             linePoints: 0,       // Points from row/column clears (base, before difficulty multiplier)
             squarePoints: 0,     // Points from 3x3 square clears (base)
-            comboBonusPoints: 0  // Points from combo bonuses added in the moment of clear (base)
+            comboBonusPoints: 0, // Points from combo bonuses added in the moment of clear (base)
+            placementPoints: 0   // Points from block placements (base)
         };
         
         // Scoring multipliers
@@ -352,6 +353,9 @@ export class ScoringSystem {
         const adjustedPoints = Math.floor(gained * difficultyMultiplier);
         this.score += adjustedPoints;
         this.lastScoreGained = adjustedPoints;
+        
+        // Track placement points in breakdown
+        this.pointsBreakdown.placementPoints += adjustedPoints;
 
         // Update level using compounding thresholds
         this.updateLevelFromScore();
@@ -410,7 +414,7 @@ export class ScoringSystem {
         this.columnsClearedCount = 0;
         this.squaresClearedCount = 0;
         this.comboActivations = 0;
-        this.pointsBreakdown = { linePoints: 0, squarePoints: 0, comboBonusPoints: 0 };
+        this.pointsBreakdown = { linePoints: 0, squarePoints: 0, comboBonusPoints: 0, placementPoints: 0 };
     }
 
     // ---------- Level Progression Helpers ----------
@@ -513,7 +517,8 @@ export class ScoringSystem {
             breakdownBase: {
                 linePoints: this.pointsBreakdown.linePoints,
                 squarePoints: this.pointsBreakdown.squarePoints,
-                comboBonusPoints: this.pointsBreakdown.comboBonusPoints
+                comboBonusPoints: this.pointsBreakdown.comboBonusPoints,
+                placementPoints: this.pointsBreakdown.placementPoints
             }
         };
     }


### PR DESCRIPTION
Correct game over score breakdown by including placement points and fixing combo bonus display.

The previous game over popup's score breakdown was incomplete, omitting block placement points and incorrectly calculating combo bonuses due to duplicate logic, leading to a mismatch with the final score. This PR ensures all scoring components are accurately reflected in the breakdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-d315e7c2-280f-48ed-867c-f72f63860001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d315e7c2-280f-48ed-867c-f72f63860001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

