### PR TITLE
Fix level up notification bug

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2156,6 +2156,12 @@ class BlockdokuGame {
             this.score = savedState.score || 0;
             this.level = savedState.level || 1;
             
+            // Initialize previous values to match loaded state to prevent false animations
+            this.previousScore = this.score;
+            this.previousLevel = this.level;
+            this.previousCombo = 0;
+            this.previousTotalCombos = 0;
+            
             // Fully synchronize scoring system state
             this.scoringSystem.score = this.score;
             this.scoringSystem.level = this.level;


### PR DESCRIPTION
Initialize previous game state values in `loadGameState` to prevent false level up and score animations when returning from settings.

Previously, `loadGameState` would load the current `level` and `score` but reset `previousLevel` and `previousScore` to their defaults. This caused the `render()` method's animation logic to incorrectly trigger level up and score increase notifications, as `this.level > this.previousLevel` or `this.score > this.previousScore` would evaluate to true even when no actual progress was made.

---
<a href="https://cursor.com/background-agent?bcId=bc-218bdfb8-cd5a-4e52-98d9-1972df6133b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-218bdfb8-cd5a-4e52-98d9-1972df6133b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

