### PR TITLE
Change block placement sound to pop

### DIFF
--- a/src/js/effects/sound-manager.js
+++ b/src/js/effects/sound-manager.js
@@ -236,12 +236,13 @@ export class SoundManager {
     
     // Create block placement sound
     createBlockPlaceSound() {
-        const buffer = this.audioContext.createBuffer(1, this.audioContext.sampleRate * 0.1, this.audioContext.sampleRate);
+        const buffer = this.audioContext.createBuffer(1, this.audioContext.sampleRate * 0.08, this.audioContext.sampleRate);
         const data = buffer.getChannelData(0);
         
         for (let i = 0; i < data.length; i++) {
             const t = i / this.audioContext.sampleRate;
-            data[i] = Math.sin(2 * Math.PI * 800 * t) * Math.exp(-t * 10) * 0.3;
+            const freq = 300 - t * 200;
+            data[i] = Math.sin(2 * Math.PI * freq * t) * Math.exp(-t * 20) * 0.4;
         }
         
         return { buffer, volume: 0.7 };


### PR DESCRIPTION
Change the default block placement sound effect to a 'pop' sound by adjusting its duration, frequency, decay, and amplitude.

---
<a href="https://cursor.com/background-agent?bcId=bc-44ecf33b-6f99-446c-b25b-b5d87d92d48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44ecf33b-6f99-446c-b25b-b5d87d92d48a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

