### PR TITLE
Investigate sound option grouping not taking effect

### DIFF
--- a/src/js/effects/sound-manager.js
+++ b/src/js/effects/sound-manager.js
@@ -160,30 +160,25 @@ export class SoundManager {
     // Get grouped sound effects for simplified settings
     getGroupedSoundEffects() {
         return {
-            neutral: {
-                name: 'Neutral Events',
+            events: {
+                name: 'Events',
                 description: 'General gameplay actions like block placement and UI interactions',
-                sounds: ['blockPlace', 'blockRotate', 'buttonClick', 'undo', 'redo']
+                sounds: ['blockPlace', 'blockRotate', 'buttonClick', 'undo', 'redo', 'hint']
             },
-            positive: {
-                name: 'Positive Events', 
+            success: {
+                name: 'Success', 
                 description: 'Achievements, rewards, and successful actions',
                 sounds: ['lineClear', 'levelUp', 'combo', 'scoreGain', 'perfect', 'chain', 'timeBonus']
             },
             warning: {
-                name: 'Warning Events',
+                name: 'Warning',
                 description: 'Time pressure alerts and urgent notifications',
                 sounds: ['timeWarning', 'timeCritical']
             },
-            error: {
-                name: 'Error Events',
+            failure: {
+                name: 'Failure',
                 description: 'Mistakes and invalid actions',
                 sounds: ['error']
-            },
-            helper: {
-                name: 'Helper Events',
-                description: 'Assistance and guidance features',
-                sounds: ['hint']
             }
         };
     }
@@ -605,7 +600,7 @@ export class SoundManager {
         
         // Apply the preset to all sounds in the group
         for (const soundKey of groupInfo.sounds) {
-            this.setCustomSoundMapping(soundKey, presetId);
+            this.setCustomSound(soundKey, presetId);
         }
     }
     


### PR DESCRIPTION
Correct `setGroupedSoundSettings` method call and update sound effect groups to reflect 'events, success, warning, failure' categories.

The `setGroupedSoundSettings` method was calling a non-existent `setCustomSoundMapping` method, preventing grouped sound settings from applying. This PR fixes the method call and reconfigures the sound effect groups to align with the user's intended categories and consolidate sounds.

---
<a href="https://cursor.com/background-agent?bcId=bc-5acf12c1-9b41-4af8-bea6-40a6c6c596c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5acf12c1-9b41-4af8-bea6-40a6c6c596c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

