### PR TITLE
Fix combo scoreboard update after combo recognition

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1185,6 +1185,8 @@ class BlockdokuGame {
             if (scoreInfo.isComboEvent) {
                 this.scoringSystem.combo++;
                 this.scoringSystem.maxCombo = Math.max(this.scoringSystem.maxCombo, this.scoringSystem.combo);
+                this.scoringSystem.totalCombos++;
+                this.scoringSystem.maxTotalCombos = Math.max(this.scoringSystem.maxTotalCombos, this.scoringSystem.totalCombos);
                 this.scoringSystem.comboActivations++;
             } else {
                 this.scoringSystem.combo = 0;


### PR DESCRIPTION
Increment `totalCombos` and `maxTotalCombos` to correctly update the combo scoreboard.

The game's UI displays the `totalCombos` (cumulative combos), but the `updateScoreForClears` function was only incrementing the `combo` (streak combo) counter. This caused the combo scoreboard to remain at 0 even when combos were achieved and points awarded. This PR ensures `totalCombos` is also updated.

---
<a href="https://cursor.com/background-agent?bcId=bc-3646f1f5-c202-489a-84a8-f76c7546c287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3646f1f5-c202-489a-84a8-f76c7546c287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

