### PR TITLE
Adjust settings selection press duration

### DIFF
--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -132,44 +132,155 @@ class SettingsManager {
     }
     
     setupEventListeners() {
-        // Navigation
+        // Navigation with press duration requirement
         document.querySelectorAll('.nav-item').forEach(item => {
-            const handleNavClick = (e) => {
+            let pressStartTime = null;
+            let pressTimeout = null;
+            let isPressed = false;
+            
+            const handleNavActivation = (e) => {
                 e.preventDefault();
                 this.showSection(item.dataset.section);
             };
             
-            item.addEventListener('click', handleNavClick);
-            item.addEventListener('touchstart', (e) => {
+            const startPress = (e) => {
                 e.preventDefault();
-                handleNavClick(e);
-            }, { passive: false });
+                if (isPressed) return; // Already pressing
+                
+                isPressed = true;
+                pressStartTime = Date.now();
+                
+                // Add visual feedback
+                item.classList.add('pressing');
+                
+                // Set timeout for 1.5 seconds
+                pressTimeout = setTimeout(() => {
+                    if (isPressed) {
+                        handleNavActivation(e);
+                        this.resetPressState(item, pressTimeout, isPressed);
+                    }
+                }, 1500);
+            };
+            
+            const cancelPress = (e) => {
+                if (!isPressed) return;
+                
+                e.preventDefault();
+                this.resetPressState(item, pressTimeout, isPressed);
+            };
+            
+            // Mouse events
+            item.addEventListener('mousedown', startPress);
+            item.addEventListener('mouseup', cancelPress);
+            item.addEventListener('mouseleave', cancelPress);
+            
+            // Touch events
+            item.addEventListener('touchstart', startPress, { passive: false });
+            item.addEventListener('touchend', cancelPress, { passive: false });
+            item.addEventListener('touchcancel', cancelPress, { passive: false });
+            
+            // Fallback click handler for accessibility
+            item.addEventListener('click', (e) => {
+                e.preventDefault();
+                // Only allow click if it's a quick press (accessibility)
+                if (!isPressed && (!pressStartTime || (Date.now() - pressStartTime) < 200)) {
+                    handleNavActivation(e);
+                }
+            });
         });
         
-        // Theme selection
+        // Theme selection with press duration requirement
         document.querySelectorAll('.theme-option').forEach(option => {
-            const handleThemeClick = (e) => {
+            let pressStartTime = null;
+            let pressTimeout = null;
+            let isPressed = false;
+            
+            const handleThemeActivation = (e) => {
                 this.selectTheme(e.currentTarget.dataset.theme);
             };
             
-            option.addEventListener('click', handleThemeClick);
-            option.addEventListener('touchstart', (e) => {
+            const startPress = (e) => {
                 e.preventDefault();
-                handleThemeClick(e);
-            }, { passive: false });
+                if (isPressed) return;
+                
+                isPressed = true;
+                pressStartTime = Date.now();
+                option.classList.add('pressing');
+                
+                pressTimeout = setTimeout(() => {
+                    if (isPressed) {
+                        handleThemeActivation(e);
+                        this.resetPressState(option, pressTimeout, isPressed);
+                    }
+                }, 1500);
+            };
+            
+            const cancelPress = (e) => {
+                if (!isPressed) return;
+                e.preventDefault();
+                this.resetPressState(option, pressTimeout, isPressed);
+            };
+            
+            option.addEventListener('mousedown', startPress);
+            option.addEventListener('mouseup', cancelPress);
+            option.addEventListener('mouseleave', cancelPress);
+            option.addEventListener('touchstart', startPress, { passive: false });
+            option.addEventListener('touchend', cancelPress, { passive: false });
+            option.addEventListener('touchcancel', cancelPress, { passive: false });
+            
+            option.addEventListener('click', (e) => {
+                e.preventDefault();
+                if (!isPressed && (!pressStartTime || (Date.now() - pressStartTime) < 200)) {
+                    handleThemeActivation(e);
+                }
+            });
         });
         
-        // Difficulty selection
+        // Difficulty selection with press duration requirement
         document.querySelectorAll('.difficulty-option').forEach(option => {
-            const handleDifficultyClick = async (e) => {
+            let pressStartTime = null;
+            let pressTimeout = null;
+            let isPressed = false;
+            
+            const handleDifficultyActivation = async (e) => {
                 await this.selectDifficulty(e.currentTarget.dataset.difficulty);
             };
             
-            option.addEventListener('click', handleDifficultyClick);
-            option.addEventListener('touchstart', async (e) => {
+            const startPress = (e) => {
                 e.preventDefault();
-                await handleDifficultyClick(e);
-            }, { passive: false });
+                if (isPressed) return;
+                
+                isPressed = true;
+                pressStartTime = Date.now();
+                option.classList.add('pressing');
+                
+                pressTimeout = setTimeout(async () => {
+                    if (isPressed) {
+                        await handleDifficultyActivation(e);
+                        this.resetPressState(option, pressTimeout, isPressed);
+                    }
+                }, 1500);
+            };
+            
+            const cancelPress = (e) => {
+                if (!isPressed) return;
+                e.preventDefault();
+                this.resetPressState(option, pressTimeout, isPressed);
+            };
+            
+            option.addEventListener('mousedown', startPress);
+            option.addEventListener('mouseup', cancelPress);
+            option.addEventListener('mouseleave', cancelPress);
+            option.addEventListener('touchstart', startPress, { passive: false });
+            option.addEventListener('touchend', cancelPress, { passive: false });
+            option.addEventListener('touchcancel', cancelPress, { passive: false });
+            
+            option.addEventListener('click', async (e) => {
+                e.preventDefault();
+                if (!isPressed && (!pressStartTime || (Date.now() - pressStartTime) < 200)) {
+                    await handleDifficultyActivation(e);
+                }
+            });
         });
         
         // Game settings
@@ -295,6 +406,16 @@ class SettingsManager {
                 this.showNotification('Statistics reset');
             });
         }
+    }
+    
+    resetPressState(item, pressTimeout, isPressed) {
+        // Clear timeout
+        if (pressTimeout) {
+            clearTimeout(pressTimeout);
+        }
+        
+        // Remove visual feedback
+        item.classList.remove('pressing');
     }
     
     showSection(sectionName) {

--- a/src/settings.html
+++ b/src/settings.html
@@ -123,6 +123,51 @@
             text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
         }
         
+        .nav-item.pressing {
+            background: var(--primary-color);
+            color: white;
+            text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+            transform: scale(0.98);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .nav-item.pressing::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
+            animation: pressProgress 1.5s linear forwards;
+        }
+        
+        @keyframes pressProgress {
+            from { width: 0%; }
+            to { width: 100%; }
+        }
+        
+        /* Press duration styles for theme and difficulty options */
+        .theme-option.pressing,
+        .difficulty-option.pressing {
+            transform: scale(0.98);
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+            position: relative;
+            overflow: hidden;
+        }
+        
+        .theme-option.pressing::after,
+        .difficulty-option.pressing::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
+            animation: pressProgress 1.5s linear forwards;
+        }
+        
         /* Override for light theme to ensure readability */
         [data-theme="light"] .nav-item.active,
         body.light-theme .nav-item.active,


### PR DESCRIPTION
Add a 1.5-second press duration to settings page selections to prevent accidental activations.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaab40fa-a094-4df1-b742-d9cd50043d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eaab40fa-a094-4df1-b742-d9cd50043d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

