### PR TITLE
Implement speed penalty for scoring

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2307,13 +2307,9 @@ class BlockdokuGame {
         // Load combo display mode from settings
         this.comboModeActive = settings.comboDisplayMode || 'cumulative';
         
-        // Load speed bonus setting
-        const enableSpeedBonus = settings.enableSpeedBonus !== false; // Default to true
-        this.scoringSystem.setSpeedBonusEnabled(enableSpeedBonus);
-        
-        // Load speed punishment setting
-        const enableSpeedPunishment = settings.enableSpeedPunishment === true; // Default to false
-        this.scoringSystem.setSpeedPunishmentMode(enableSpeedPunishment);
+        // Load speed mode setting (3-way: 'bonus', 'punishment', or 'ignored')
+        const speedMode = settings.speedMode || 'bonus'; // Default to 'bonus'
+        this.scoringSystem.setSpeedMode(speedMode);
     }
 
     loadGameState() {
@@ -3255,19 +3251,26 @@ class BlockdokuGame {
         const x = col * cellSize + cellSize / 2;
         const y = row * cellSize + cellSize / 2;
         
-        // Determine if we're in punishment mode
-        const isPunishment = this.scoringSystem.isSpeedPunishmentMode();
+        // Determine the current speed mode
+        const speedMode = this.scoringSystem.getSpeedMode();
         
         // Create speed bonus text element
         const speedText = document.createElement('div');
         speedText.className = 'speed-bonus-text';
-        speedText.textContent = isPunishment ? `-${bonus} Too Fast!` : `+${bonus} Speed!`;
+        
+        // Set text and color based on mode
+        if (speedMode === 'punishment') {
+            speedText.textContent = `-${bonus} Too Fast!`;
+        } else {
+            speedText.textContent = `+${bonus} Speed!`;
+        }
+        
         speedText.style.cssText = `
             position: absolute;
             left: ${x}px;
             top: ${y}px;
             transform: translate(-50%, -50%);
-            color: ${isPunishment ? '#ff3333' : '#ff6b35'};
+            color: ${speedMode === 'punishment' ? '#ff3333' : '#ff6b35'};
             font-weight: 900;
             font-size: 1.2rem;
             text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2310,6 +2310,10 @@ class BlockdokuGame {
         // Load speed bonus setting
         const enableSpeedBonus = settings.enableSpeedBonus !== false; // Default to true
         this.scoringSystem.setSpeedBonusEnabled(enableSpeedBonus);
+        
+        // Load speed punishment setting
+        const enableSpeedPunishment = settings.enableSpeedPunishment === true; // Default to false
+        this.scoringSystem.setSpeedPunishmentMode(enableSpeedPunishment);
     }
 
     loadGameState() {
@@ -3251,16 +3255,19 @@ class BlockdokuGame {
         const x = col * cellSize + cellSize / 2;
         const y = row * cellSize + cellSize / 2;
         
+        // Determine if we're in punishment mode
+        const isPunishment = this.scoringSystem.isSpeedPunishmentMode();
+        
         // Create speed bonus text element
         const speedText = document.createElement('div');
         speedText.className = 'speed-bonus-text';
-        speedText.textContent = `+${bonus} Speed!`;
+        speedText.textContent = isPunishment ? `-${bonus} Too Fast!` : `+${bonus} Speed!`;
         speedText.style.cssText = `
             position: absolute;
             left: ${x}px;
             top: ${y}px;
             transform: translate(-50%, -50%);
-            color: #ff6b35;
+            color: ${isPunishment ? '#ff3333' : '#ff6b35'};
             font-weight: 900;
             font-size: 1.2rem;
             text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8);

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -108,14 +108,20 @@ class SettingsManager {
             showHighScore.checked = this.settings.showHighScore === true; // Default to false
         }
         
-        const enableSpeedBonus = document.getElementById('enable-speed-bonus');
-        if (enableSpeedBonus) {
-            enableSpeedBonus.checked = this.settings.enableSpeedBonus !== false; // Default to true
-        }
+        // Speed mode - handle radio buttons
+        const speedModeBonus = document.getElementById('speed-mode-bonus');
+        const speedModePunishment = document.getElementById('speed-mode-punishment');
+        const speedModeIgnored = document.getElementById('speed-mode-ignored');
         
-        const enableSpeedPunishment = document.getElementById('enable-speed-punishment');
-        if (enableSpeedPunishment) {
-            enableSpeedPunishment.checked = this.settings.enableSpeedPunishment === true; // Default to false
+        if (speedModeBonus && speedModePunishment && speedModeIgnored) {
+            const mode = this.settings.speedMode || 'bonus'; // Default to 'bonus'
+            if (mode === 'bonus') {
+                speedModeBonus.checked = true;
+            } else if (mode === 'punishment') {
+                speedModePunishment.checked = true;
+            } else if (mode === 'ignored') {
+                speedModeIgnored.checked = true;
+            }
         }
         
         const showSpeedBonus = document.getElementById('show-speed-bonus');
@@ -346,32 +352,25 @@ class SettingsManager {
             });
         }
         
-        const enableSpeedBonus = document.getElementById('enable-speed-bonus');
-        if (enableSpeedBonus) {
-            enableSpeedBonus.addEventListener('change', (e) => {
-                this.updateSetting('enableSpeedBonus', e.target.checked);
-                // If speed bonus is disabled, also disable speed punishment
-                if (!e.target.checked) {
-                    const speedPunishment = document.getElementById('enable-speed-punishment');
-                    if (speedPunishment && speedPunishment.checked) {
-                        speedPunishment.checked = false;
-                        this.updateSetting('enableSpeedPunishment', false);
-                    }
+        // Speed mode radio buttons
+        const speedModeBonus = document.getElementById('speed-mode-bonus');
+        const speedModePunishment = document.getElementById('speed-mode-punishment');
+        const speedModeIgnored = document.getElementById('speed-mode-ignored');
+        
+        if (speedModeBonus && speedModePunishment && speedModeIgnored) {
+            speedModeBonus.addEventListener('change', (e) => {
+                if (e.target.checked) {
+                    this.updateSetting('speedMode', 'bonus');
                 }
             });
-        }
-        
-        const enableSpeedPunishment = document.getElementById('enable-speed-punishment');
-        if (enableSpeedPunishment) {
-            enableSpeedPunishment.addEventListener('change', (e) => {
-                this.updateSetting('enableSpeedPunishment', e.target.checked);
-                // If speed punishment is enabled, ensure speed tracking is also enabled
+            speedModePunishment.addEventListener('change', (e) => {
                 if (e.target.checked) {
-                    const speedBonus = document.getElementById('enable-speed-bonus');
-                    if (speedBonus && !speedBonus.checked) {
-                        speedBonus.checked = true;
-                        this.updateSetting('enableSpeedBonus', true);
-                    }
+                    this.updateSetting('speedMode', 'punishment');
+                }
+            });
+            speedModeIgnored.addEventListener('change', (e) => {
+                if (e.target.checked) {
+                    this.updateSetting('speedMode', 'ignored');
                 }
             });
         }

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -113,6 +113,11 @@ class SettingsManager {
             enableSpeedBonus.checked = this.settings.enableSpeedBonus !== false; // Default to true
         }
         
+        const enableSpeedPunishment = document.getElementById('enable-speed-punishment');
+        if (enableSpeedPunishment) {
+            enableSpeedPunishment.checked = this.settings.enableSpeedPunishment === true; // Default to false
+        }
+        
         const showSpeedBonus = document.getElementById('show-speed-bonus');
         if (showSpeedBonus) {
             showSpeedBonus.checked = this.settings.showSpeedBonus === true; // Default to false
@@ -345,6 +350,29 @@ class SettingsManager {
         if (enableSpeedBonus) {
             enableSpeedBonus.addEventListener('change', (e) => {
                 this.updateSetting('enableSpeedBonus', e.target.checked);
+                // If speed bonus is disabled, also disable speed punishment
+                if (!e.target.checked) {
+                    const speedPunishment = document.getElementById('enable-speed-punishment');
+                    if (speedPunishment && speedPunishment.checked) {
+                        speedPunishment.checked = false;
+                        this.updateSetting('enableSpeedPunishment', false);
+                    }
+                }
+            });
+        }
+        
+        const enableSpeedPunishment = document.getElementById('enable-speed-punishment');
+        if (enableSpeedPunishment) {
+            enableSpeedPunishment.addEventListener('change', (e) => {
+                this.updateSetting('enableSpeedPunishment', e.target.checked);
+                // If speed punishment is enabled, ensure speed tracking is also enabled
+                if (e.target.checked) {
+                    const speedBonus = document.getElementById('enable-speed-bonus');
+                    if (speedBonus && !speedBonus.checked) {
+                        speedBonus.checked = true;
+                        this.updateSetting('enableSpeedBonus', true);
+                    }
+                }
             });
         }
         

--- a/src/settings.html
+++ b/src/settings.html
@@ -766,6 +766,24 @@
                         Enable prize recognition
                     </label>
                 </div>
+                <div class="setting-item">
+                    <label>
+                        <input type="checkbox" id="enable-speed-bonus" checked />
+                        Track speed for bonus points
+                    </label>
+                </div>
+                <div class="setting-item">
+                    <label>
+                        <input type="checkbox" id="enable-speed-punishment" />
+                        Speed penalty (clever twist: faster = less points!)
+                    </label>
+                </div>
+                <div class="setting-item">
+                    <label>
+                        <input type="checkbox" id="show-speed-bonus" />
+                        Show speed tracker in utility bar
+                    </label>
+                </div>
                 <!-- PWA Install Button -->
                 <div class="setting-item pwa-install-item">
                     <button id="pwa-install-button" class="pwa-install-button">

--- a/src/settings.html
+++ b/src/settings.html
@@ -601,6 +601,84 @@
                 justify-content: center;
             }
         }
+        
+        /* Speed Mode Settings */
+        .speed-mode-settings {
+            margin: 2rem 0;
+            padding: 1.5rem;
+            background: var(--bg-color);
+            border: 2px solid var(--border-color);
+            border-radius: 12px;
+        }
+        
+        .speed-mode-settings h3 {
+            margin: 0 0 1rem 0;
+            color: var(--text-color);
+            font-size: 1.1rem;
+            font-weight: 600;
+        }
+        
+        .speed-mode-options {
+            display: grid;
+            gap: 0.75rem;
+        }
+        
+        .speed-mode-option {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            padding: 1rem;
+            background: var(--card-bg);
+            border: 2px solid var(--border-color);
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+        
+        .speed-mode-option:hover {
+            border-color: var(--primary-color);
+            transform: translateX(4px);
+        }
+        
+        .speed-mode-option input[type="radio"] {
+            width: 20px;
+            height: 20px;
+            cursor: pointer;
+            accent-color: var(--primary-color);
+        }
+        
+        .speed-mode-option input[type="radio"]:checked ~ .speed-mode-label {
+            color: var(--primary-color);
+            font-weight: 600;
+        }
+        
+        .speed-mode-label {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+            flex: 1;
+        }
+        
+        .speed-mode-label strong {
+            color: var(--text-color);
+            font-size: 1rem;
+            transition: color 0.3s ease;
+        }
+        
+        .speed-mode-label small {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+        }
+        
+        @media (max-width: 768px) {
+            .speed-mode-settings {
+                padding: 1rem;
+            }
+            
+            .speed-mode-option {
+                padding: 0.75rem;
+            }
+        }
     </style>
 </head>
 <body>
@@ -766,18 +844,35 @@
                         Enable prize recognition
                     </label>
                 </div>
-                <div class="setting-item">
-                    <label>
-                        <input type="checkbox" id="enable-speed-bonus" checked />
-                        Track speed for bonus points
-                    </label>
+                
+                <!-- Speed Mode Settings -->
+                <div class="speed-mode-settings">
+                    <h3>Speed Tracking Mode</h3>
+                    <div class="speed-mode-options">
+                        <label class="speed-mode-option">
+                            <input type="radio" name="speed-mode" value="bonus" id="speed-mode-bonus" checked />
+                            <span class="speed-mode-label">
+                                <strong>Bonus</strong>
+                                <small>Faster = more points</small>
+                            </span>
+                        </label>
+                        <label class="speed-mode-option">
+                            <input type="radio" name="speed-mode" value="punishment" id="speed-mode-punishment" />
+                            <span class="speed-mode-label">
+                                <strong>Punishment</strong>
+                                <small>Faster = less points (scales with level)</small>
+                            </span>
+                        </label>
+                        <label class="speed-mode-option">
+                            <input type="radio" name="speed-mode" value="ignored" id="speed-mode-ignored" />
+                            <span class="speed-mode-label">
+                                <strong>Ignored</strong>
+                                <small>Speed doesn't affect score</small>
+                            </span>
+                        </label>
+                    </div>
                 </div>
-                <div class="setting-item">
-                    <label>
-                        <input type="checkbox" id="enable-speed-punishment" />
-                        Speed penalty (clever twist: faster = less points!)
-                    </label>
-                </div>
+                
                 <div class="setting-item">
                     <label>
                         <input type="checkbox" id="show-speed-bonus" />


### PR DESCRIPTION
Refactor speed tracking into a 3-way toggle (Bonus, Punishment, Ignored) to provide more flexible and intuitive control over how speed affects gameplay.

This PR unifies the previous speed bonus and newly added speed punishment into a single "Speed Tracking Mode" setting with three options:
- **Bonus**: Faster placements award points.
- **Punishment**: Faster placements subtract points, with the penalty scaling slightly with the game level.
- **Ignored**: Speed is tracked for statistics but does not affect the score.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb1537ec-d780-44a1-9d7c-cf1c83aabecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb1537ec-d780-44a1-9d7c-cf1c83aabecf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

