### PR TITLE
Implement petrification game mechanic

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1010,6 +1010,55 @@ body {
     100% { box-shadow: 0 12px 35px rgba(0, 123, 255, 0.4); }
 }
 
+/* Petrification states for blocks */
+.block-item.petrified {
+    filter: grayscale(100%) brightness(0.6);
+    position: relative;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.block-item.petrified::before {
+    content: '❄';
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    font-size: 1.2rem;
+    text-shadow: 0 0 3px rgba(150, 200, 255, 0.8);
+    z-index: 10;
+    animation: frozenPulse 2s ease-in-out infinite;
+}
+
+@keyframes frozenPulse {
+    0%, 100% { opacity: 0.7; transform: scale(1); }
+    50% { opacity: 1; transform: scale(1.1); }
+}
+
+.block-item.warning-7s {
+    animation: warning7sFlash 1s ease-in-out infinite;
+}
+
+@keyframes warning7sFlash {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.7; }
+}
+
+.block-item.warning-3s {
+    animation: warning3sFlash 0.3s ease-in-out infinite;
+    border-color: #ff6b35 !important;
+}
+
+@keyframes warning3sFlash {
+    0%, 100% { 
+        opacity: 1; 
+        box-shadow: 0 0 0 rgba(255, 107, 53, 0);
+    }
+    50% { 
+        opacity: 0.6; 
+        box-shadow: 0 0 15px rgba(255, 107, 53, 0.8);
+    }
+}
+
     .block-preview {
     display: flex;
     justify-content: center;

--- a/src/js/game/petrification-manager.js
+++ b/src/js/game/petrification-manager.js
@@ -1,0 +1,397 @@
+/**
+ * Petrification Manager
+ * Tracks and manages the petrification state of grid cells and available blocks
+ */
+
+export class PetrificationManager {
+    constructor() {
+        this.enabled = false;
+        
+        // Grid cell petrification tracking
+        // Structure: { "row,col": { timestamp: Date.now(), warned7s: false, warned3s: false } }
+        this.gridCellTimestamps = {};
+        
+        // Available block petrification tracking
+        // Structure: { blockId: { timestamp: Date.now(), warned7s: false, warned3s: false } }
+        this.blockTimestamps = {};
+        
+        // Timing constants (in milliseconds)
+        this.GRID_CELL_PETRIFY_TIME = 10000; // 10 seconds
+        this.BLOCK_PETRIFY_TIME = 30000; // 30 seconds
+        this.WARNING_7S_TIME = 7000; // 7 seconds before petrification
+        this.WARNING_3S_TIME = 3000; // 3 seconds before petrification
+        
+        // Statistics
+        this.stats = {
+            gridCellsPetrified: 0,
+            blocksPetrified: 0,
+            gridCellsThawed: 0,
+            blocksThawed: 0,
+            totalPetrificationTime: 0 // Total time cells/blocks spent petrified
+        };
+    }
+    
+    /**
+     * Enable or disable the petrification system
+     */
+    setEnabled(enabled) {
+        const wasEnabled = this.enabled;
+        this.enabled = enabled;
+        
+        // If disabling, clear all petrification state and reset times
+        if (wasEnabled && !enabled) {
+            this.resetAll();
+        }
+    }
+    
+    /**
+     * Check if petrification is enabled
+     */
+    isEnabled() {
+        return this.enabled;
+    }
+    
+    /**
+     * Reset all petrification tracking (called when toggling off)
+     */
+    resetAll() {
+        this.gridCellTimestamps = {};
+        this.blockTimestamps = {};
+    }
+    
+    /**
+     * Track a grid cell that was just filled
+     */
+    trackGridCell(row, col) {
+        if (!this.enabled) return;
+        
+        const key = `${row},${col}`;
+        this.gridCellTimestamps[key] = {
+            timestamp: Date.now(),
+            warned7s: false,
+            warned3s: false,
+            petrified: false
+        };
+    }
+    
+    /**
+     * Untrack a grid cell (when it's cleared)
+     */
+    untrackGridCell(row, col) {
+        const key = `${row},${col}`;
+        delete this.gridCellTimestamps[key];
+    }
+    
+    /**
+     * Track an available block
+     */
+    trackBlock(blockId) {
+        if (!this.enabled) return;
+        
+        this.blockTimestamps[blockId] = {
+            timestamp: Date.now(),
+            warned7s: false,
+            warned3s: false,
+            petrified: false
+        };
+    }
+    
+    /**
+     * Untrack a block (when it's placed)
+     */
+    untrackBlock(blockId) {
+        delete this.blockTimestamps[blockId];
+    }
+    
+    /**
+     * Update tracking for current board state
+     * Called after block placement to track new cells
+     */
+    updateBoardTracking(board) {
+        if (!this.enabled) return;
+        
+        // Track all filled cells
+        for (let row = 0; row < board.length; row++) {
+            for (let col = 0; col < board[row].length; col++) {
+                const key = `${row},${col}`;
+                if (board[row][col] === 1) {
+                    // Only track if not already tracked
+                    if (!this.gridCellTimestamps[key]) {
+                        this.trackGridCell(row, col);
+                    }
+                } else {
+                    // Remove tracking for empty cells
+                    if (this.gridCellTimestamps[key]) {
+                        this.untrackGridCell(row, col);
+                    }
+                }
+            }
+        }
+    }
+    
+    /**
+     * Update tracking for available blocks
+     */
+    updateBlockTracking(blocks) {
+        if (!this.enabled) return;
+        
+        const currentBlockIds = new Set(blocks.map(b => b.id));
+        
+        // Track new blocks
+        blocks.forEach(block => {
+            if (!this.blockTimestamps[block.id]) {
+                this.trackBlock(block.id);
+            }
+        });
+        
+        // Remove tracking for blocks that no longer exist
+        Object.keys(this.blockTimestamps).forEach(blockId => {
+            if (!currentBlockIds.has(blockId)) {
+                this.untrackBlock(blockId);
+            }
+        });
+    }
+    
+    /**
+     * Get petrification state for a grid cell
+     * Returns: { petrified: boolean, warning: '7s' | '3s' | null, timeRemaining: number }
+     */
+    getGridCellState(row, col) {
+        if (!this.enabled) {
+            return { petrified: false, warning: null, timeRemaining: Infinity };
+        }
+        
+        const key = `${row},${col}`;
+        const data = this.gridCellTimestamps[key];
+        
+        if (!data) {
+            return { petrified: false, warning: null, timeRemaining: Infinity };
+        }
+        
+        const elapsed = Date.now() - data.timestamp;
+        const timeRemaining = this.GRID_CELL_PETRIFY_TIME - elapsed;
+        
+        if (elapsed >= this.GRID_CELL_PETRIFY_TIME) {
+            if (!data.petrified) {
+                data.petrified = true;
+                this.stats.gridCellsPetrified++;
+            }
+            return { petrified: true, warning: null, timeRemaining: 0 };
+        }
+        
+        if (timeRemaining <= this.WARNING_3S_TIME) {
+            return { petrified: false, warning: '3s', timeRemaining };
+        }
+        
+        if (timeRemaining <= this.WARNING_7S_TIME) {
+            return { petrified: false, warning: '7s', timeRemaining };
+        }
+        
+        return { petrified: false, warning: null, timeRemaining };
+    }
+    
+    /**
+     * Get petrification state for a block
+     * Returns: { petrified: boolean, warning: '7s' | '3s' | null, timeRemaining: number }
+     */
+    getBlockState(blockId) {
+        if (!this.enabled) {
+            return { petrified: false, warning: null, timeRemaining: Infinity };
+        }
+        
+        const data = this.blockTimestamps[blockId];
+        
+        if (!data) {
+            return { petrified: false, warning: null, timeRemaining: Infinity };
+        }
+        
+        const elapsed = Date.now() - data.timestamp;
+        const timeRemaining = this.BLOCK_PETRIFY_TIME - elapsed;
+        
+        if (elapsed >= this.BLOCK_PETRIFY_TIME) {
+            if (!data.petrified) {
+                data.petrified = true;
+                this.stats.blocksPetrified++;
+            }
+            return { petrified: true, warning: null, timeRemaining: 0 };
+        }
+        
+        if (timeRemaining <= this.WARNING_3S_TIME) {
+            return { petrified: false, warning: '3s', timeRemaining };
+        }
+        
+        if (timeRemaining <= this.WARNING_7S_TIME) {
+            return { petrified: false, warning: '7s', timeRemaining };
+        }
+        
+        return { petrified: false, warning: null, timeRemaining };
+    }
+    
+    /**
+     * Check if a grid cell is petrified
+     */
+    isGridCellPetrified(row, col) {
+        return this.getGridCellState(row, col).petrified;
+    }
+    
+    /**
+     * Check if a block is petrified
+     */
+    isBlockPetrified(blockId) {
+        return this.getBlockState(blockId).petrified;
+    }
+    
+    /**
+     * Check if a line can be cleared (no petrified cells)
+     * Returns true if the line can be cleared (no petrified cells)
+     */
+    canClearRow(board, row) {
+        if (!this.enabled) return true;
+        
+        for (let col = 0; col < board[row].length; col++) {
+            if (board[row][col] === 1 && this.isGridCellPetrified(row, col)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    canClearColumn(board, col) {
+        if (!this.enabled) return true;
+        
+        for (let row = 0; row < board.length; row++) {
+            if (board[row][col] === 1 && this.isGridCellPetrified(row, col)) {
+                return false;
+            }
+        }
+        return true;
+    }
+    
+    canClearSquare(board, squareRow, squareCol) {
+        if (!this.enabled) return true;
+        
+        const startRow = squareRow * 3;
+        const startCol = squareCol * 3;
+        
+        for (let r = startRow; r < startRow + 3; r++) {
+            for (let c = startCol; c < startCol + 3; c++) {
+                if (board[r][c] === 1 && this.isGridCellPetrified(r, c)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+    
+    /**
+     * Thaw (unpetrify) all grid cells and blocks after a clear event
+     */
+    thawAll() {
+        if (!this.enabled) return;
+        
+        // Thaw grid cells
+        Object.keys(this.gridCellTimestamps).forEach(key => {
+            const data = this.gridCellTimestamps[key];
+            if (data.petrified) {
+                this.stats.gridCellsThawed++;
+            }
+            data.petrified = false;
+            data.timestamp = Date.now();
+            data.warned7s = false;
+            data.warned3s = false;
+        });
+        
+        // Thaw blocks
+        Object.keys(this.blockTimestamps).forEach(blockId => {
+            const data = this.blockTimestamps[blockId];
+            if (data.petrified) {
+                this.stats.blocksThawed++;
+            }
+            data.petrified = false;
+            data.timestamp = Date.now();
+            data.warned7s = false;
+            data.warned3s = false;
+        });
+    }
+    
+    /**
+     * Get all petrified grid cells
+     * Returns: Array of { row, col }
+     */
+    getPetrifiedGridCells() {
+        const petrified = [];
+        
+        Object.keys(this.gridCellTimestamps).forEach(key => {
+            const [row, col] = key.split(',').map(Number);
+            if (this.isGridCellPetrified(row, col)) {
+                petrified.push({ row, col });
+            }
+        });
+        
+        return petrified;
+    }
+    
+    /**
+     * Get all petrified blocks
+     * Returns: Array of block IDs
+     */
+    getPetrifiedBlocks() {
+        return Object.keys(this.blockTimestamps).filter(blockId => 
+            this.isBlockPetrified(blockId)
+        );
+    }
+    
+    /**
+     * Get statistics
+     */
+    getStats() {
+        return {
+            ...this.stats,
+            currentPetrifiedCells: this.getPetrifiedGridCells().length,
+            currentPetrifiedBlocks: this.getPetrifiedBlocks().length
+        };
+    }
+    
+    /**
+     * Reset statistics
+     */
+    resetStats() {
+        this.stats = {
+            gridCellsPetrified: 0,
+            blocksPetrified: 0,
+            gridCellsThawed: 0,
+            blocksThawed: 0,
+            totalPetrificationTime: 0
+        };
+    }
+    
+    /**
+     * Serialize state for saving
+     */
+    serialize() {
+        return {
+            enabled: this.enabled,
+            gridCellTimestamps: this.gridCellTimestamps,
+            blockTimestamps: this.blockTimestamps,
+            stats: this.stats
+        };
+    }
+    
+    /**
+     * Deserialize state from saved data
+     */
+    deserialize(data) {
+        if (!data) return;
+        
+        this.enabled = data.enabled || false;
+        this.gridCellTimestamps = data.gridCellTimestamps || {};
+        this.blockTimestamps = data.blockTimestamps || {};
+        this.stats = data.stats || {
+            gridCellsPetrified: 0,
+            blocksPetrified: 0,
+            gridCellsThawed: 0,
+            blocksThawed: 0,
+            totalPetrificationTime: 0
+        };
+    }
+}

--- a/src/js/game/scoring.js
+++ b/src/js/game/scoring.js
@@ -4,10 +4,13 @@
  */
 
 export class ScoringSystem {
-    constructor() {
+    constructor(petrificationManager = null) {
         this.score = 0;
         this.level = 1;
         this.linesCleared = 0;
+        
+        // Petrification manager (optional)
+        this.petrificationManager = petrificationManager;
         
         // Dual combo tracking system
         this.combo = 0;                    // Current streak combo
@@ -76,7 +79,13 @@ export class ScoringSystem {
         };
     }
     
+    // Set petrification manager
+    setPetrificationManager(petrificationManager) {
+        this.petrificationManager = petrificationManager;
+    }
+    
     // Check for completed lines without clearing them
+    // Now respects petrification - lines with petrified cells cannot be cleared
     checkForCompletedLines(board) {
         const clearedLines = {
             rows: [],
@@ -87,14 +96,20 @@ export class ScoringSystem {
         // Check rows
         for (let row = 0; row < board.length; row++) {
             if (this.isRowComplete(board, row)) {
-                clearedLines.rows.push(row);
+                // Check if row can be cleared (no petrified cells)
+                if (!this.petrificationManager || this.petrificationManager.canClearRow(board, row)) {
+                    clearedLines.rows.push(row);
+                }
             }
         }
         
         // Check columns
         for (let col = 0; col < board[0].length; col++) {
             if (this.isColumnComplete(board, col)) {
-                clearedLines.columns.push(col);
+                // Check if column can be cleared (no petrified cells)
+                if (!this.petrificationManager || this.petrificationManager.canClearColumn(board, col)) {
+                    clearedLines.columns.push(col);
+                }
             }
         }
         
@@ -102,7 +117,10 @@ export class ScoringSystem {
         for (let squareRow = 0; squareRow < 3; squareRow++) {
             for (let squareCol = 0; squareCol < 3; squareCol++) {
                 if (this.isSquareComplete(board, squareRow, squareCol)) {
-                    clearedLines.squares.push({ row: squareRow, col: squareCol });
+                    // Check if square can be cleared (no petrified cells)
+                    if (!this.petrificationManager || this.petrificationManager.canClearSquare(board, squareRow, squareCol)) {
+                        clearedLines.squares.push({ row: squareRow, col: squareCol });
+                    }
                 }
             }
         }

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -92,6 +92,10 @@ class SettingsManager {
             enableTimer.checked = this.settings.enableTimer === true; // Default to false
         }
         
+        const enablePetrification = document.getElementById('enable-petrification');
+        if (enablePetrification) {
+            enablePetrification.checked = this.settings.enablePetrification === true; // Default to false
+        }
         
         const autoSave = document.getElementById('auto-save');
         if (autoSave) {
@@ -298,6 +302,12 @@ class SettingsManager {
             this.updateSetting('enableTimer', e.target.checked);
         });
         
+        const enablePetrification = document.getElementById('enable-petrification');
+        if (enablePetrification) {
+            enablePetrification.addEventListener('change', (e) => {
+                this.updateSetting('enablePetrification', e.target.checked);
+            });
+        }
         
         document.getElementById('sound-enabled').addEventListener('change', (e) => {
             this.updateSetting('soundEnabled', e.target.checked);

--- a/src/js/storage/game-storage.js
+++ b/src/js/storage/game-storage.js
@@ -146,6 +146,7 @@ export class GameStorage {
             autoSave: true,
             enableHints: false,
             enableTimer: false,
+            enablePetrification: false,
             enableUndo: false,
             showPoints: false,
             showHighScore: false,

--- a/src/settings.html
+++ b/src/settings.html
@@ -725,6 +725,13 @@
                 </div>
                 <div class="setting-item">
                     <label>
+                        <input type="checkbox" id="enable-petrification" />
+                        Enable petrification
+                    </label>
+                    <p class="setting-description">Grid cells petrify after 10s and blocks after 30s in place. Petrified cells can't be cleared until a clear event happens. Adds strategic time pressure!</p>
+                </div>
+                <div class="setting-item">
+                    <label>
                         <input type="checkbox" id="show-high-score" />
                         Show current high score in header
                     </label>


### PR DESCRIPTION
Add a 'Petrification' game setting that makes grid cells and available blocks petrify after a set time, introducing a new strategic challenge.

This feature tracks the time blocks spend on the grid or in the palette, applying visual warnings and petrifying them to prevent clearing until a line clear event occurs. It includes a settings toggle, visual effects, and end-game statistics.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a8460d1-89c5-4898-960b-4115abcb866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a8460d1-89c5-4898-960b-4115abcb866f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

