### PR TITLE
Adjust touch response for settings and difficulty

### DIFF
--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -186,6 +186,21 @@ class SettingsManager {
                 this.showSection(item.dataset.section);
             };
             
+            const resetPressState = () => {
+                // Clear timeout
+                if (pressTimeout) {
+                    clearTimeout(pressTimeout);
+                    pressTimeout = null;
+                }
+                
+                // Reset state
+                isPressed = false;
+                pressStartTime = null;
+                
+                // Remove visual feedback
+                item.classList.remove('pressing');
+            };
+            
             const startPress = (e) => {
                 e.preventDefault();
                 if (isPressed) return; // Already pressing
@@ -196,20 +211,20 @@ class SettingsManager {
                 // Add visual feedback
                 item.classList.add('pressing');
                 
-                // Set timeout for 1.5 seconds
+                // Set timeout for 0.75 seconds
                 pressTimeout = setTimeout(() => {
                     if (isPressed) {
                         handleNavActivation(e);
-                        this.resetPressState(item, pressTimeout, isPressed);
+                        resetPressState();
                     }
-                }, 1500);
+                }, 750);
             };
             
             const cancelPress = (e) => {
                 if (!isPressed) return;
                 
                 e.preventDefault();
-                this.resetPressState(item, pressTimeout, isPressed);
+                resetPressState();
             };
             
             // Mouse events
@@ -242,6 +257,21 @@ class SettingsManager {
                 this.selectTheme(e.currentTarget.dataset.theme);
             };
             
+            const resetPressState = () => {
+                // Clear timeout
+                if (pressTimeout) {
+                    clearTimeout(pressTimeout);
+                    pressTimeout = null;
+                }
+                
+                // Reset state
+                isPressed = false;
+                pressStartTime = null;
+                
+                // Remove visual feedback
+                option.classList.remove('pressing');
+            };
+            
             const startPress = (e) => {
                 e.preventDefault();
                 if (isPressed) return;
@@ -253,15 +283,15 @@ class SettingsManager {
                 pressTimeout = setTimeout(() => {
                     if (isPressed) {
                         handleThemeActivation(e);
-                        this.resetPressState(option, pressTimeout, isPressed);
+                        resetPressState();
                     }
-                }, 1500);
+                }, 750);
             };
             
             const cancelPress = (e) => {
                 if (!isPressed) return;
                 e.preventDefault();
-                this.resetPressState(option, pressTimeout, isPressed);
+                resetPressState();
             };
             
             option.addEventListener('mousedown', startPress);
@@ -289,6 +319,21 @@ class SettingsManager {
                 await this.selectDifficulty(e.currentTarget.dataset.difficulty);
             };
             
+            const resetPressState = () => {
+                // Clear timeout
+                if (pressTimeout) {
+                    clearTimeout(pressTimeout);
+                    pressTimeout = null;
+                }
+                
+                // Reset state
+                isPressed = false;
+                pressStartTime = null;
+                
+                // Remove visual feedback
+                option.classList.remove('pressing');
+            };
+            
             const startPress = (e) => {
                 e.preventDefault();
                 if (isPressed) return;
@@ -300,15 +345,15 @@ class SettingsManager {
                 pressTimeout = setTimeout(async () => {
                     if (isPressed) {
                         await handleDifficultyActivation(e);
-                        this.resetPressState(option, pressTimeout, isPressed);
+                        resetPressState();
                     }
-                }, 1500);
+                }, 750);
             };
             
             const cancelPress = (e) => {
                 if (!isPressed) return;
                 e.preventDefault();
-                this.resetPressState(option, pressTimeout, isPressed);
+                resetPressState();
             };
             
             option.addEventListener('mousedown', startPress);
@@ -506,15 +551,6 @@ class SettingsManager {
         }
     }
     
-    resetPressState(item, pressTimeout, isPressed) {
-        // Clear timeout
-        if (pressTimeout) {
-            clearTimeout(pressTimeout);
-        }
-        
-        // Remove visual feedback
-        item.classList.remove('pressing');
-    }
     
     showSection(sectionName) {
         // Update navigation

--- a/src/settings.html
+++ b/src/settings.html
@@ -140,7 +140,7 @@
             left: 0;
             height: 100%;
             background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
-            animation: pressProgress 1.5s linear forwards;
+            animation: pressProgress 0.75s linear forwards;
         }
         
         @keyframes pressProgress {
@@ -165,7 +165,7 @@
             left: 0;
             height: 100%;
             background: linear-gradient(90deg, transparent 0%, rgba(255, 255, 255, 0.3) 50%, transparent 100%);
-            animation: pressProgress 1.5s linear forwards;
+            animation: pressProgress 0.75s linear forwards;
         }
         
         /* Override for light theme to ensure readability */


### PR DESCRIPTION
Reduce touch activation time to 0.75s and fix unreliable event registration on settings page.

The previous touch handling implementation had a bug where the `isPressed` state was not properly reset after an interaction, leading to subsequent touch events being ignored. This PR refactors the touch event listeners to manage `isPressed` and `pressTimeout` locally within each item's scope, ensuring reliable event registration and preventing the reported issue of being unable to make selections. CSS animations are also updated to match the new timing.

---
<a href="https://cursor.com/background-agent?bcId=bc-d88fa21e-9570-40c3-b8af-a0b0a8b47264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d88fa21e-9570-40c3-b8af-a0b0a8b47264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

