### PR TITLE
Fix unplaceable new game blocks

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -335,7 +335,10 @@ class BlockdokuGame {
         }
 
         // Update placeability indicators each tick for responsiveness
-        this.updatePlaceabilityIndicators();
+        // Only update if game is initialized and has blocks
+        if (this.isInitialized && this.blockManager && this.blockManager.currentBlocks && this.blockManager.currentBlocks.length > 0) {
+            this.updatePlaceabilityIndicators();
+        }
     }
     
     draw() {
@@ -1660,9 +1663,6 @@ class BlockdokuGame {
         if (this.blockPalette && this.blockPalette.stopTimeoutChecking) {
             this.blockPalette.stopTimeoutChecking();
         }
-        
-        // Update placeability indicators for new game
-        this.updatePlaceabilityIndicators();
         
         // Reset animation tracking
         this.previousScore = 0;


### PR DESCRIPTION
Remove premature calls to `updatePlaceabilityIndicators()` to fix blocks appearing muted on new game start.

The `updatePlaceabilityIndicators()` method was being called both redundantly in `newGame()` before blocks were generated, and continuously in the game loop's `update()` method before the game was fully initialized. This caused blocks to be incorrectly marked as unplaceable, resulting in the muted appearance. The fix ensures placeability is only checked when blocks are present and the game is ready.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c46a494-f800-4311-bdf0-63fa0fefa409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c46a494-f800-4311-bdf0-63fa0fefa409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

