### PR TITLE
Debug placement and speed points display

### DIFF
--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -129,6 +129,11 @@ class SettingsManager {
             showPoints.checked = this.settings.showPoints === true; // Default to false
         }
 
+        const showPlacementPoints = document.getElementById('show-placement-points');
+        if (showPlacementPoints) {
+            showPlacementPoints.checked = this.settings.showPlacementPoints === true; // Default to false
+        }
+
         const showHighScore = document.getElementById('show-high-score');
         if (showHighScore) {
             showHighScore.checked = this.settings.showHighScore === true; // Default to false
@@ -451,6 +456,13 @@ class SettingsManager {
             this.updateSetting('showPoints', e.target.checked);
             this.updateBlockPointsDisplay();
         });
+
+        const showPlacementPoints = document.getElementById('show-placement-points');
+        if (showPlacementPoints) {
+            showPlacementPoints.addEventListener('change', (e) => {
+                this.updateSetting('showPlacementPoints', e.target.checked);
+            });
+        }
 
         const showHighScore = document.getElementById('show-high-score');
         if (showHighScore) {

--- a/src/js/storage/game-storage.js
+++ b/src/js/storage/game-storage.js
@@ -151,6 +151,7 @@ export class GameStorage {
             deadPixelsIntensity: 0,
             enableUndo: false,
             showPoints: false,
+            showPlacementPoints: false,
             showHighScore: false,
             comboDisplayMode: 'cumulative' // 'streak' or 'cumulative'
         };

--- a/src/settings.html
+++ b/src/settings.html
@@ -871,6 +871,13 @@
                 </div>
                 <div class="setting-item">
                     <label>
+                        <input type="checkbox" id="show-placement-points" />
+                        Show placement points
+                    </label>
+                    <p class="setting-description">Show floating point notifications when placing blocks (can be noisy if enabled)</p>
+                </div>
+                <div class="setting-item">
+                    <label>
                         <input type="checkbox" id="enable-prize-recognition" checked />
                         Enable prize recognition
                     </label>


### PR DESCRIPTION
Synchronize scoreboard updates for block placement and speed points, add a toggle for placement point notifications, and respect speed bonus display settings.

Previously, the main game score was not being updated from the scoring system after points were added for block placement or speed bonuses, causing the scoreboard to appear unresponsive. This PR also introduces a new setting to control the visual feedback for placement points and ensures speed bonus feedback adheres to its respective setting.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c8b2ce3-35b2-4b5f-97f6-c94655917d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c8b2ce3-35b2-4b5f-97f6-c94655917d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

