### PR TITLE
Fix block clear and stuck state bug

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1345,11 +1345,19 @@ class BlockdokuGame {
         // Start glow effect immediately
         this.highlightClearingBlocks(clearedLines);
         
-        // After 0.75 seconds, actually clear the lines and show effects
-        setTimeout(() => {
+        // Store the timeout ID so we can cancel it if needed
+        this.clearTimeoutId = setTimeout(() => {
             console.log('Timeout reached, calling completeLineClear');
             this.completeLineClear(clearedLines);
         }, 750);
+        
+        // Add a safety timeout to prevent permanent stuck state
+        this.safetyTimeoutId = setTimeout(() => {
+            if (this.pendingClears) {
+                console.warn('Safety timeout reached - forcing line clear completion');
+                this.forceCompleteLineClear(clearedLines);
+            }
+        }, 2000); // 2 seconds safety timeout
     }
     
     showImmediateClearFeedback(clearedLines) {
@@ -1570,15 +1578,30 @@ class BlockdokuGame {
         let combo;
         
         try {
-            // Clear pending clears state FIRST to prevent stuck UI
-            this.pendingClears = null;
-            this.pendingClearsTimestamp = null;
-            
-            // Actually clear the lines from the board (without updating score)
+            // Actually clear the lines from the board FIRST (without updating score)
             console.log('Clearing lines from board...');
             result = this.scoringSystem.clearLinesFromBoard(this.board, clearedLines);
             console.log('Lines cleared from board, result:', result);
-            this.board = result.board;
+            
+            // Only clear pending state AFTER successful clearing
+            if (result && result.board) {
+                this.board = result.board;
+                // Clear pending clears state AFTER successful board update
+                this.pendingClears = null;
+                this.pendingClearsTimestamp = null;
+                // Clear timeouts since we completed successfully
+                if (this.clearTimeoutId) {
+                    clearTimeout(this.clearTimeoutId);
+                    this.clearTimeoutId = null;
+                }
+                if (this.safetyTimeoutId) {
+                    clearTimeout(this.safetyTimeoutId);
+                    this.safetyTimeoutId = null;
+                }
+            } else {
+                console.error('Failed to clear lines from board, keeping pending state');
+                return; // Exit early if clearing failed
+            }
             
             // Thaw all petrified cells and blocks after a clear event
             this.petrificationManager.thawAll();
@@ -1600,10 +1623,27 @@ class BlockdokuGame {
             console.log('Line clear completed. Score was already updated. Current score:', this.score, 'Current level:', this.level);
         } catch (error) {
             console.error('Error during line clear completion:', error);
-            // Reset pending clears state even if there was an error
-            this.pendingClears = null;
-            this.pendingClearResult = null;
-            this.pendingClearsTimestamp = null;
+            // Don't reset pending state on error - this causes the stuck state
+            // Instead, try to recover by attempting the clear again
+            console.log('Attempting recovery from line clear error...');
+            
+            // Try to clear the lines again as a recovery attempt
+            try {
+                const recoveryResult = this.scoringSystem.clearLinesFromBoard(this.board, clearedLines);
+                if (recoveryResult && recoveryResult.board) {
+                    this.board = recoveryResult.board;
+                    this.pendingClears = null;
+                    this.pendingClearsTimestamp = null;
+                    this.pendingClearResult = null;
+                    console.log('Recovery successful, lines cleared');
+                } else {
+                    console.error('Recovery failed, keeping pending state for manual intervention');
+                    // Keep pending state so user can use resetStuckUIState() if needed
+                }
+            } catch (recoveryError) {
+                console.error('Recovery attempt also failed:', recoveryError);
+                // Keep pending state for manual intervention
+            }
             return;
         }
         
@@ -1646,6 +1686,48 @@ class BlockdokuGame {
         setTimeout(() => {
             this.checkLineClears();
         }, 200);
+    }
+    
+    // Force complete line clear when stuck (safety mechanism)
+    forceCompleteLineClear(clearedLines) {
+        console.log('Force completing line clear for:', clearedLines);
+        
+        try {
+            // Clear timeouts first
+            if (this.clearTimeoutId) {
+                clearTimeout(this.clearTimeoutId);
+                this.clearTimeoutId = null;
+            }
+            if (this.safetyTimeoutId) {
+                clearTimeout(this.safetyTimeoutId);
+                this.safetyTimeoutId = null;
+            }
+            
+            // Force clear the lines
+            const result = this.scoringSystem.clearLinesFromBoard(this.board, clearedLines);
+            if (result && result.board) {
+                this.board = result.board;
+                this.pendingClears = null;
+                this.pendingClearsTimestamp = null;
+                this.pendingClearResult = null;
+                
+                // Thaw petrified cells
+                this.petrificationManager.thawAll();
+                this.petrificationManager.updateBoardTracking(this.board);
+                
+                // Update UI
+                this.updateUI();
+                this.updatePlaceabilityIndicators();
+                
+                console.log('Force clear completed successfully');
+            } else {
+                console.error('Force clear failed - using emergency reset');
+                this.resetStuckUIState();
+            }
+        } catch (error) {
+            console.error('Force clear error:', error);
+            this.resetStuckUIState();
+        }
     }
     
     newGame() {
@@ -3520,6 +3602,17 @@ class BlockdokuGame {
         // Clear any pending clears that might be causing red highlighting
         this.pendingClears = null;
         this.pendingClearResult = null;
+        this.pendingClearsTimestamp = null;
+        
+        // Clear any active timeouts
+        if (this.clearTimeoutId) {
+            clearTimeout(this.clearTimeoutId);
+            this.clearTimeoutId = null;
+        }
+        if (this.safetyTimeoutId) {
+            clearTimeout(this.safetyTimeoutId);
+            this.safetyTimeoutId = null;
+        }
         
         // Force refresh the board display
         this.drawBoard();


### PR DESCRIPTION
Fix race condition in line clearing mechanism to prevent stuck UI states where blocks glow but don't clear.

The previous implementation reset the `pendingClears` state prematurely, before the actual board clearing was confirmed. This, combined with a lack of error handling, led to a desynchronized UI where blocks showed a blue glow but never cleared, eventually resulting in a "red block stuck state". The fix reorders state updates, adds a safety timeout, and introduces recovery mechanisms to ensure the board state and UI remain consistent.

---
<a href="https://cursor.com/background-agent?bcId=bc-074d7e5b-45e8-411c-acac-76fd9d896be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-074d7e5b-45e8-411c-acac-76fd9d896be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

