### PR TITLE
Optimize game settings selection latency

### DIFF
--- a/PWA_DEBUGGING_LESSONS.md
+++ b/PWA_DEBUGGING_LESSONS.md
@@ -44,7 +44,7 @@ class StateManager { /* state management only */ }
 - **Global Access**: SettingsManager must be available globally (`window.settingsManager`)
 - **Persistence Issues**: UI and game logic can get out of sync - always validate
 - **Section Organization**: Large settings pages should be split into dedicated pages
-- **Touch Responsiveness**: 100ms touch delay provides good balance of responsiveness vs intentionality
+- **Touch Responsiveness**: 10ms touch delay provides optimal responsiveness for settings page interactions
 
 ---
 
@@ -103,7 +103,7 @@ if (document.readyState === 'loading') {
 **Lesson**: Touch events need careful handling to prevent accidental interactions.
 
 **Key Insights**:
-- **Touch and Hold**: 100ms delay provides good balance (was 750ms, too slow)
+- **Touch and Hold**: 10ms delay provides optimal responsiveness (was 100ms, now optimized for settings)
 - **Event Prevention**: Always use `preventDefault()` and `passive: false`
 - **Visual Feedback**: Show pressing state during touch interactions
 - **Multiple Event Types**: Handle both touch and mouse events
@@ -123,7 +123,7 @@ const startPress = (e) => {
       handleActivation();
       resetPressState();
     }
-  }, 100); // Optimal delay
+  }, 10); // Optimal delay for settings page responsiveness
 };
 ```
 

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -273,7 +273,7 @@ export class SettingsManager {
                         handleNavActivation(e);
                         resetPressState();
                     }
-                }, 100);
+                }, 10);
             };
             
             const cancelPress = (e) => {
@@ -343,7 +343,7 @@ export class SettingsManager {
                         handleThemeActivation(themeValue);
                         resetPressState();
                     }
-                }, 100);
+                }, 10);
             };
             
             const cancelPress = (e) => {
@@ -405,7 +405,7 @@ export class SettingsManager {
                         await handleDifficultyActivation(e);
                         resetPressState();
                     }
-                }, 100);
+                }, 10);
             };
             
             const cancelPress = (e) => {


### PR DESCRIPTION
Reduce touch delay for settings page item selection from 100ms to 10ms to improve responsiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-e1e65a3c-cbf2-4aa2-8119-bd9cf196832e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e1e65a3c-cbf2-4aa2-8119-bd9cf196832e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

